### PR TITLE
Extended LinkML compatibility, added OSC-EM acquisition info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,6 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 .notebook/
+
+# random
+test/

--- a/docs/AcquisitionMetadataMixin.md
+++ b/docs/AcquisitionMetadataMixin.md
@@ -1,0 +1,154 @@
+
+
+# Class: AcquisitionMetadataMixin
+
+
+_Metadata concerning the acquisition process._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:AcquisitionMetadataMixin](https://w3id.org/cetmd/entities/:AcquisitionMetadataMixin)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class AcquisitionMetadataMixin
+    click AcquisitionMetadataMixin href "../AcquisitionMetadataMixin"
+      AcquisitionMetadataMixin <|-- MovieFrame
+        click MovieFrame href "../MovieFrame"
+      AcquisitionMetadataMixin <|-- ProjectionImage
+        click ProjectionImage href "../ProjectionImage"
+      
+      AcquisitionMetadataMixin : accumulated_dose
+        
+      AcquisitionMetadataMixin : ctf_metadata
+        
+          
+    
+    
+    AcquisitionMetadataMixin --> "0..1" CTFMetadata : ctf_metadata
+    click CTFMetadata href "../CTFMetadata"
+
+        
+      AcquisitionMetadataMixin : nominal_tilt_angle
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [nominal_tilt_angle](nominal_tilt_angle.md) | 0..1 <br/> [Float](Float.md) | The tilt angle reported by the microscope | direct |
+| [accumulated_dose](accumulated_dose.md) | 0..1 <br/> [Float](Float.md) | The pre-exposure up to this image in e-/A^2 | direct |
+| [ctf_metadata](ctf_metadata.md) | 0..1 <br/> [CTFMetadata](CTFMetadata.md) | A set of CTF patameters for an image | direct |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:AcquisitionMetadataMixin |
+| native | https://w3id.org/cetmd/entities/:AcquisitionMetadataMixin |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: AcquisitionMetadataMixin
+description: Metadata concerning the acquisition process.
+from_schema: https://w3id.org/cetmd/entities
+slots:
+- nominal_tilt_angle
+- accumulated_dose
+- ctf_metadata
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: AcquisitionMetadataMixin
+description: Metadata concerning the acquisition process.
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  nominal_tilt_angle:
+    name: nominal_tilt_angle
+    description: The tilt angle reported by the microscope
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: nominal_tilt_angle
+    owner: AcquisitionMetadataMixin
+    domain_of:
+    - AcquisitionMetadataMixin
+    range: float
+  accumulated_dose:
+    name: accumulated_dose
+    description: The pre-exposure up to this image in e-/A^2
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: accumulated_dose
+    owner: AcquisitionMetadataMixin
+    domain_of:
+    - AcquisitionMetadataMixin
+    range: float
+  ctf_metadata:
+    name: ctf_metadata
+    description: A set of CTF patameters for an image.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: ctf_metadata
+    owner: AcquisitionMetadataMixin
+    domain_of:
+    - AcquisitionMetadataMixin
+    range: CTFMetadata
+
+```
+</details>

--- a/docs/Affine.md
+++ b/docs/Affine.md
@@ -1,0 +1,90 @@
+
+
+# Slot: affine
+
+
+_The affine matrix_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:affine](https://w3id.org/cetmd/entities/:affine)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Affine](Affine.md) | An affine transformation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Integer](Integer.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:affine |
+| native | https://w3id.org/cetmd/entities/:affine |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: affine
+description: The affine matrix
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+array:
+  exact_number_dimensions: 2
+  dimensions:
+  - alias: exact_card
+    exact_cardinality: 3
+  - alias: exact_card
+    exact_cardinality: 3
+alias: affine
+owner: Affine
+domain_of:
+- Affine
+range: integer
+
+```
+</details>

--- a/docs/Alignment.md
+++ b/docs/Alignment.md
@@ -1,0 +1,137 @@
+
+
+# Class: Alignment
+
+
+_The tomographic alignment for a tilt series._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:Alignment](https://w3id.org/cetmd/entities/:Alignment)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class Alignment
+    click Alignment href "../Alignment"
+      Alignment : projection_alignments
+        
+          
+    
+    
+    Alignment --> "*" ProjectionAlignment : projection_alignments
+    click ProjectionAlignment href "../ProjectionAlignment"
+
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [projection_alignments](projection_alignments.md) | * <br/> [ProjectionAlignment](ProjectionAlignment.md) | alignment for a specific projection | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [Region](Region.md) | [alignments](alignments.md) | range | [Alignment](Alignment.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:Alignment |
+| native | https://w3id.org/cetmd/entities/:Alignment |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: Alignment
+description: The tomographic alignment for a tilt series.
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  projection_alignments:
+    name: projection_alignments
+    description: alignment for a specific projection
+    from_schema: https://w3id.org/cetmd/alignment/
+    rank: 1000
+    domain_of:
+    - Alignment
+    range: ProjectionAlignment
+    multivalued: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: Alignment
+description: The tomographic alignment for a tilt series.
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  projection_alignments:
+    name: projection_alignments
+    description: alignment for a specific projection
+    from_schema: https://w3id.org/cetmd/alignment/
+    rank: 1000
+    alias: projection_alignments
+    owner: Alignment
+    domain_of:
+    - Alignment
+    range: ProjectionAlignment
+    multivalued: true
+
+```
+</details>

--- a/docs/Annotation.md
+++ b/docs/Annotation.md
@@ -1,0 +1,167 @@
+
+
+# Class: Annotation
+
+
+_A primitive annotation._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:Annotation](https://w3id.org/cetmd/entities/:Annotation)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class Annotation
+    click Annotation href "../Annotation"
+      Annotation <|-- SegmentationMask2D
+        click SegmentationMask2D href "../SegmentationMask2D"
+      Annotation <|-- SegmentationMask3D
+        click SegmentationMask3D href "../SegmentationMask3D"
+      Annotation <|-- ProbabilityMap2D
+        click ProbabilityMap2D href "../ProbabilityMap2D"
+      Annotation <|-- ProbabilityMap3D
+        click ProbabilityMap3D href "../ProbabilityMap3D"
+      Annotation <|-- PointSet2D
+        click PointSet2D href "../PointSet2D"
+      Annotation <|-- PointSet3D
+        click PointSet3D href "../PointSet3D"
+      Annotation <|-- PointVectorSet2D
+        click PointVectorSet2D href "../PointVectorSet2D"
+      Annotation <|-- PointVectorSet3D
+        click PointVectorSet3D href "../PointVectorSet3D"
+      Annotation <|-- PointMatrixSet2D
+        click PointMatrixSet2D href "../PointMatrixSet2D"
+      Annotation <|-- PointMatrixSet3D
+        click PointMatrixSet3D href "../PointMatrixSet3D"
+      Annotation <|-- TriMesh
+        click TriMesh href "../TriMesh"
+      
+      Annotation : path
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* **Annotation**
+    * [SegmentationMask2D](SegmentationMask2D.md) [ [Image2D](Image2D.md)]
+    * [SegmentationMask3D](SegmentationMask3D.md) [ [Image3D](Image3D.md)]
+    * [ProbabilityMap2D](ProbabilityMap2D.md) [ [Image2D](Image2D.md)]
+    * [ProbabilityMap3D](ProbabilityMap3D.md) [ [Image3D](Image3D.md)]
+    * [PointSet2D](PointSet2D.md) [ [CoordMetaMixin](CoordMetaMixin.md)]
+    * [PointSet3D](PointSet3D.md) [ [CoordMetaMixin](CoordMetaMixin.md)]
+    * [PointVectorSet2D](PointVectorSet2D.md) [ [CoordMetaMixin](CoordMetaMixin.md)]
+    * [PointVectorSet3D](PointVectorSet3D.md) [ [CoordMetaMixin](CoordMetaMixin.md)]
+    * [PointMatrixSet2D](PointMatrixSet2D.md) [ [CoordMetaMixin](CoordMetaMixin.md)]
+    * [PointMatrixSet3D](PointMatrixSet3D.md) [ [CoordMetaMixin](CoordMetaMixin.md)]
+    * [TriMesh](TriMesh.md) [ [CoordMetaMixin](CoordMetaMixin.md)]
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [path](path.md) | 0..1 <br/> [String](String.md) | Path to a file | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [Region](Region.md) | [annotations](annotations.md) | range | [Annotation](Annotation.md) |
+| [Average](Average.md) | [annotations](annotations.md) | range | [Annotation](Annotation.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:Annotation |
+| native | https://w3id.org/cetmd/entities/:Annotation |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: Annotation
+description: A primitive annotation.
+from_schema: https://w3id.org/cetmd/entities
+slots:
+- path
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: Annotation
+description: A primitive annotation.
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: path
+    owner: Annotation
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    range: string
+
+```
+</details>

--- a/docs/Average.md
+++ b/docs/Average.md
@@ -1,0 +1,178 @@
+
+
+# Class: Average
+
+
+_A particle averaging experiment._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:Average](https://w3id.org/cetmd/entities/:Average)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class Average
+    click Average href "../Average"
+      Average : annotations
+        
+          
+    
+    
+    Average --> "*" Annotation : annotations
+    click Annotation href "../Annotation"
+
+        
+      Average : name
+        
+      Average : particle_maps
+        
+          
+    
+    
+    Average --> "*" ParticleMap : particle_maps
+    click ParticleMap href "../ParticleMap"
+
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [name](name.md) | 0..1 <br/> [String](String.md) | The name of a given entry | direct |
+| [annotations](annotations.md) | * <br/> [Annotation](Annotation.md) | The annotations | direct |
+| [particle_maps](particle_maps.md) | * <br/> [ParticleMap](ParticleMap.md) | The particle maps | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [Dataset](Dataset.md) | [averages](averages.md) | range | [Average](Average.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:Average |
+| native | https://w3id.org/cetmd/entities/:Average |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: Average
+description: A particle averaging experiment.
+from_schema: https://w3id.org/cetmd/entities
+slots:
+- name
+- annotations
+attributes:
+  particle_maps:
+    name: particle_maps
+    description: The particle maps
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    domain_of:
+    - Average
+    range: ParticleMap
+    multivalued: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: Average
+description: A particle averaging experiment.
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  particle_maps:
+    name: particle_maps
+    description: The particle maps
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: particle_maps
+    owner: Average
+    domain_of:
+    - Average
+    range: ParticleMap
+    multivalued: true
+  name:
+    name: name
+    description: The name of a given entry
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: name
+    owner: Average
+    domain_of:
+    - Average
+    - Dataset
+    - CoordinateSystem
+    - CoordinateTransformation
+    range: string
+  annotations:
+    name: annotations
+    description: The annotations
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: annotations
+    owner: Average
+    domain_of:
+    - Region
+    - Average
+    range: Annotation
+    multivalued: true
+
+```
+</details>

--- a/docs/Axis.md
+++ b/docs/Axis.md
@@ -1,0 +1,157 @@
+
+
+# Class: Axis
+
+
+_An axis in a coordinate system_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:Axis](https://w3id.org/cetmd/entities/:Axis)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class Axis
+    click Axis href "../Axis"
+      Axis : axis_name
+        
+      Axis : axis_type
+        
+          
+    
+    
+    Axis --> "0..1" AxisType : axis_type
+    click AxisType href "../AxisType"
+
+        
+      Axis : axis_unit
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [axis_name](axis_name.md) | 0..1 <br/> [String](String.md) | The name of the axis | direct |
+| [axis_unit](axis_unit.md) | 0..1 <br/> [String](String.md) | The unit of the axis | direct |
+| [axis_type](axis_type.md) | 0..1 <br/> [AxisType](AxisType.md) | The type of axis | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [CoordinateSystem](CoordinateSystem.md) | [axes](axes.md) | range | [Axis](Axis.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:Axis |
+| native | https://w3id.org/cetmd/entities/:Axis |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: Axis
+description: An axis in a coordinate system
+from_schema: https://w3id.org/cetmd/entities
+slots:
+- axis_name
+- axis_unit
+- axis_type
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: Axis
+description: An axis in a coordinate system
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  axis_name:
+    name: axis_name
+    description: The name of the axis
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: axis_name
+    owner: Axis
+    domain_of:
+    - Axis
+    range: string
+  axis_unit:
+    name: axis_unit
+    description: The unit of the axis
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    ifabsent: angstrom
+    alias: axis_unit
+    owner: Axis
+    domain_of:
+    - Axis
+    range: string
+  axis_type:
+    name: axis_type
+    description: The type of axis
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: axis_type
+    owner: Axis
+    domain_of:
+    - Axis
+    range: AxisType
+
+```
+</details>

--- a/docs/Axis.md
+++ b/docs/Axis.md
@@ -46,7 +46,7 @@ URI: [https://w3id.org/cetmd/entities/:Axis](https://w3id.org/cetmd/entities/:Ax
 
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
-| [axis_name](axis_name.md) | 0..1 <br/> [String](String.md) | The name of the axis | direct |
+| [axis_name](axis_name.md) | 1 <br/> [String](String.md) | The name of the axis | direct |
 | [axis_unit](axis_unit.md) | 0..1 <br/> [String](String.md) | The unit of the axis | direct |
 | [axis_type](axis_type.md) | 0..1 <br/> [AxisType](AxisType.md) | The type of axis | direct |
 
@@ -109,6 +109,10 @@ slots:
 - axis_name
 - axis_unit
 - axis_type
+slot_usage:
+  axis_name:
+    name: axis_name
+    required: true
 
 ```
 </details>
@@ -120,6 +124,10 @@ slots:
 name: Axis
 description: An axis in a coordinate system
 from_schema: https://w3id.org/cetmd/entities
+slot_usage:
+  axis_name:
+    name: axis_name
+    required: true
 attributes:
   axis_name:
     name: axis_name
@@ -131,6 +139,7 @@ attributes:
     domain_of:
     - Axis
     range: string
+    required: true
   axis_unit:
     name: axis_unit
     description: The unit of the axis

--- a/docs/AxisNameMapping.md
+++ b/docs/AxisNameMapping.md
@@ -1,0 +1,149 @@
+
+
+# Class: AxisNameMapping
+
+
+_Axis name to Axis name mapping_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:AxisNameMapping](https://w3id.org/cetmd/entities/:AxisNameMapping)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class AxisNameMapping
+    click AxisNameMapping href "../AxisNameMapping"
+      AxisNameMapping : axis1_name
+        
+      AxisNameMapping : axis2_name
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [axis1_name](axis1_name.md) | 0..1 <br/> [String](String.md) | The type of transformation | direct |
+| [axis2_name](axis2_name.md) | 0..1 <br/> [String](String.md) | The mapping of the axis names | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [MapAxis](MapAxis.md) | [map_axis](map_axis.md) | range | [AxisNameMapping](AxisNameMapping.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:AxisNameMapping |
+| native | https://w3id.org/cetmd/entities/:AxisNameMapping |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: AxisNameMapping
+description: Axis name to Axis name mapping
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  axis1_name:
+    name: axis1_name
+    description: The type of transformation
+    from_schema: https://w3id.org/cetmd/coord_transforms
+    rank: 1000
+    domain_of:
+    - AxisNameMapping
+    range: string
+  axis2_name:
+    name: axis2_name
+    description: The mapping of the axis names
+    from_schema: https://w3id.org/cetmd/coord_transforms
+    rank: 1000
+    domain_of:
+    - AxisNameMapping
+    range: string
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: AxisNameMapping
+description: Axis name to Axis name mapping
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  axis1_name:
+    name: axis1_name
+    description: The type of transformation
+    from_schema: https://w3id.org/cetmd/coord_transforms
+    rank: 1000
+    alias: axis1_name
+    owner: AxisNameMapping
+    domain_of:
+    - AxisNameMapping
+    range: string
+  axis2_name:
+    name: axis2_name
+    description: The mapping of the axis names
+    from_schema: https://w3id.org/cetmd/coord_transforms
+    rank: 1000
+    alias: axis2_name
+    owner: AxisNameMapping
+    domain_of:
+    - AxisNameMapping
+    range: string
+
+```
+</details>

--- a/docs/AxisType.md
+++ b/docs/AxisType.md
@@ -1,0 +1,68 @@
+# Enum: AxisType
+
+
+
+
+_The type of axis_
+
+
+
+URI: [AxisType](AxisType.md)
+
+## Permissible Values
+
+| Value | Meaning | Description |
+| --- | --- | --- |
+| space | None | A spatial axis |
+| array | None | An array axis |
+
+
+
+
+## Slots
+
+| Name | Description |
+| ---  | --- |
+| [axis_type](axis_type.md) | The type of axis |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: AxisType
+description: The type of axis
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+permissible_values:
+  space:
+    text: space
+    description: A spatial axis
+  array:
+    text: array
+    description: An array axis
+
+```
+</details>

--- a/docs/Boolean.md
+++ b/docs/Boolean.md
@@ -1,0 +1,50 @@
+# Type: Boolean
+
+
+
+
+_A binary (true or false) value_
+
+
+
+URI: [xsd:boolean](http://www.w3.org/2001/XMLSchema#boolean)
+
+* [base](https://w3id.org/linkml/base): Bool
+
+* [uri](https://w3id.org/linkml/uri): xsd:boolean
+
+* [repr](https://w3id.org/linkml/repr): bool
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:boolean |
+| native | https://w3id.org/cetmd/entities/:boolean |
+| exact | schema:Boolean |
+
+
+

--- a/docs/CTFMetadata.md
+++ b/docs/CTFMetadata.md
@@ -1,0 +1,152 @@
+
+
+# Class: CTFMetadata
+
+
+_A set of CTF patameters for an image._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:CTFMetadata](https://w3id.org/cetmd/entities/:CTFMetadata)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class CTFMetadata
+    click CTFMetadata href "../CTFMetadata"
+      CTFMetadata : defocus_angle
+        
+      CTFMetadata : defocus_u
+        
+      CTFMetadata : defocus_v
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [defocus_u](defocus_u.md) | 0..1 <br/> [Float](Float.md) | Estimated defocus U for this image in Angstrom, underfocus positive | direct |
+| [defocus_v](defocus_v.md) | 0..1 <br/> [Float](Float.md) | Estimated defocus V for this image in Angstrom, underfocus positive | direct |
+| [defocus_angle](defocus_angle.md) | 0..1 <br/> [Float](Float.md) | Estimated angle of astigmatism | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md) | [ctf_metadata](ctf_metadata.md) | range | [CTFMetadata](CTFMetadata.md) |
+| [MovieFrame](MovieFrame.md) | [ctf_metadata](ctf_metadata.md) | range | [CTFMetadata](CTFMetadata.md) |
+| [ProjectionImage](ProjectionImage.md) | [ctf_metadata](ctf_metadata.md) | range | [CTFMetadata](CTFMetadata.md) |
+| [SubProjectionImage](SubProjectionImage.md) | [ctf_metadata](ctf_metadata.md) | range | [CTFMetadata](CTFMetadata.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:CTFMetadata |
+| native | https://w3id.org/cetmd/entities/:CTFMetadata |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: CTFMetadata
+description: A set of CTF patameters for an image.
+from_schema: https://w3id.org/cetmd/entities
+slots:
+- defocus_u
+- defocus_v
+- defocus_angle
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: CTFMetadata
+description: A set of CTF patameters for an image.
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  defocus_u:
+    name: defocus_u
+    description: Estimated defocus U for this image in Angstrom, underfocus positive.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: defocus_u
+    owner: CTFMetadata
+    domain_of:
+    - CTFMetadata
+    range: float
+  defocus_v:
+    name: defocus_v
+    description: Estimated defocus V for this image in Angstrom, underfocus positive.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: defocus_v
+    owner: CTFMetadata
+    domain_of:
+    - CTFMetadata
+    range: float
+  defocus_angle:
+    name: defocus_angle
+    description: Estimated angle of astigmatism.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: defocus_angle
+    owner: CTFMetadata
+    domain_of:
+    - CTFMetadata
+    range: float
+
+```
+</details>

--- a/docs/CoordMetaMixin.md
+++ b/docs/CoordMetaMixin.md
@@ -1,0 +1,163 @@
+
+
+# Class: CoordMetaMixin
+
+
+_Coordinate system mixins for annotations._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:CoordMetaMixin](https://w3id.org/cetmd/entities/:CoordMetaMixin)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class CoordMetaMixin
+    click CoordMetaMixin href "../CoordMetaMixin"
+      CoordMetaMixin <|-- PointSet2D
+        click PointSet2D href "../PointSet2D"
+      CoordMetaMixin <|-- PointSet3D
+        click PointSet3D href "../PointSet3D"
+      CoordMetaMixin <|-- PointVectorSet2D
+        click PointVectorSet2D href "../PointVectorSet2D"
+      CoordMetaMixin <|-- PointVectorSet3D
+        click PointVectorSet3D href "../PointVectorSet3D"
+      CoordMetaMixin <|-- PointMatrixSet2D
+        click PointMatrixSet2D href "../PointMatrixSet2D"
+      CoordMetaMixin <|-- PointMatrixSet3D
+        click PointMatrixSet3D href "../PointMatrixSet3D"
+      CoordMetaMixin <|-- TriMesh
+        click TriMesh href "../TriMesh"
+      
+      CoordMetaMixin : coordinate_systems
+        
+          
+    
+    
+    CoordMetaMixin --> "*" CoordinateSystem : coordinate_systems
+    click CoordinateSystem href "../CoordinateSystem"
+
+        
+      CoordMetaMixin : coordinate_transformations
+        
+          
+    
+    
+    CoordMetaMixin --> "*" CoordinateTransformation : coordinate_transformations
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [coordinate_systems](coordinate_systems.md) | * <br/> [CoordinateSystem](CoordinateSystem.md) | Named coordinate systems for this entity | direct |
+| [coordinate_transformations](coordinate_transformations.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md) | Named coordinate systems for this entity | direct |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:CoordMetaMixin |
+| native | https://w3id.org/cetmd/entities/:CoordMetaMixin |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: CoordMetaMixin
+description: Coordinate system mixins for annotations.
+from_schema: https://w3id.org/cetmd/entities
+slots:
+- coordinate_systems
+- coordinate_transformations
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: CoordMetaMixin
+description: Coordinate system mixins for annotations.
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_systems
+    owner: CoordMetaMixin
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_transformations
+    owner: CoordMetaMixin
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateTransformation
+    multivalued: true
+
+```
+</details>

--- a/docs/CoordinateSystem.md
+++ b/docs/CoordinateSystem.md
@@ -1,0 +1,186 @@
+
+
+# Class: CoordinateSystem
+
+
+_A coordinate system_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:CoordinateSystem](https://w3id.org/cetmd/entities/:CoordinateSystem)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class CoordinateSystem
+    click CoordinateSystem href "../CoordinateSystem"
+      CoordinateSystem : axes
+        
+          
+    
+    
+    CoordinateSystem --> "1..*" Axis : axes
+    click Axis href "../Axis"
+
+        
+      CoordinateSystem : name
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [name](name.md) | 1 <br/> [String](String.md) | The name of the coordinate system | direct |
+| [axes](axes.md) | 1..* <br/> [Axis](Axis.md) | The axes of the coordinate system | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [Image2D](Image2D.md) | [coordinate_systems](coordinate_systems.md) | range | [CoordinateSystem](CoordinateSystem.md) |
+| [Image3D](Image3D.md) | [coordinate_systems](coordinate_systems.md) | range | [CoordinateSystem](CoordinateSystem.md) |
+| [GainFile](GainFile.md) | [coordinate_systems](coordinate_systems.md) | range | [CoordinateSystem](CoordinateSystem.md) |
+| [DefectFile](DefectFile.md) | [coordinate_systems](coordinate_systems.md) | range | [CoordinateSystem](CoordinateSystem.md) |
+| [MovieFrame](MovieFrame.md) | [coordinate_systems](coordinate_systems.md) | range | [CoordinateSystem](CoordinateSystem.md) |
+| [ProjectionImage](ProjectionImage.md) | [coordinate_systems](coordinate_systems.md) | range | [CoordinateSystem](CoordinateSystem.md) |
+| [SubProjectionImage](SubProjectionImage.md) | [coordinate_systems](coordinate_systems.md) | range | [CoordinateSystem](CoordinateSystem.md) |
+| [Tomogram](Tomogram.md) | [coordinate_systems](coordinate_systems.md) | range | [CoordinateSystem](CoordinateSystem.md) |
+| [ParticleMap](ParticleMap.md) | [coordinate_systems](coordinate_systems.md) | range | [CoordinateSystem](CoordinateSystem.md) |
+| [CoordMetaMixin](CoordMetaMixin.md) | [coordinate_systems](coordinate_systems.md) | range | [CoordinateSystem](CoordinateSystem.md) |
+| [SegmentationMask2D](SegmentationMask2D.md) | [coordinate_systems](coordinate_systems.md) | range | [CoordinateSystem](CoordinateSystem.md) |
+| [SegmentationMask3D](SegmentationMask3D.md) | [coordinate_systems](coordinate_systems.md) | range | [CoordinateSystem](CoordinateSystem.md) |
+| [ProbabilityMap2D](ProbabilityMap2D.md) | [coordinate_systems](coordinate_systems.md) | range | [CoordinateSystem](CoordinateSystem.md) |
+| [ProbabilityMap3D](ProbabilityMap3D.md) | [coordinate_systems](coordinate_systems.md) | range | [CoordinateSystem](CoordinateSystem.md) |
+| [PointSet2D](PointSet2D.md) | [coordinate_systems](coordinate_systems.md) | range | [CoordinateSystem](CoordinateSystem.md) |
+| [PointSet3D](PointSet3D.md) | [coordinate_systems](coordinate_systems.md) | range | [CoordinateSystem](CoordinateSystem.md) |
+| [PointVectorSet2D](PointVectorSet2D.md) | [coordinate_systems](coordinate_systems.md) | range | [CoordinateSystem](CoordinateSystem.md) |
+| [PointVectorSet3D](PointVectorSet3D.md) | [coordinate_systems](coordinate_systems.md) | range | [CoordinateSystem](CoordinateSystem.md) |
+| [PointMatrixSet2D](PointMatrixSet2D.md) | [coordinate_systems](coordinate_systems.md) | range | [CoordinateSystem](CoordinateSystem.md) |
+| [PointMatrixSet3D](PointMatrixSet3D.md) | [coordinate_systems](coordinate_systems.md) | range | [CoordinateSystem](CoordinateSystem.md) |
+| [TriMesh](TriMesh.md) | [coordinate_systems](coordinate_systems.md) | range | [CoordinateSystem](CoordinateSystem.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:CoordinateSystem |
+| native | https://w3id.org/cetmd/entities/:CoordinateSystem |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: CoordinateSystem
+description: A coordinate system
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  name:
+    name: name
+    description: The name of the coordinate system
+    from_schema: https://w3id.org/cetmd/coordinate_systems
+    domain_of:
+    - Average
+    - Dataset
+    - CoordinateSystem
+    - CoordinateTransformation
+    range: string
+    required: true
+  axes:
+    name: axes
+    description: The axes of the coordinate system
+    from_schema: https://w3id.org/cetmd/coordinate_systems
+    rank: 1000
+    domain_of:
+    - CoordinateSystem
+    range: Axis
+    required: true
+    multivalued: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: CoordinateSystem
+description: A coordinate system
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  name:
+    name: name
+    description: The name of the coordinate system
+    from_schema: https://w3id.org/cetmd/coordinate_systems
+    alias: name
+    owner: CoordinateSystem
+    domain_of:
+    - Average
+    - Dataset
+    - CoordinateSystem
+    - CoordinateTransformation
+    range: string
+    required: true
+  axes:
+    name: axes
+    description: The axes of the coordinate system
+    from_schema: https://w3id.org/cetmd/coordinate_systems
+    rank: 1000
+    alias: axes
+    owner: CoordinateSystem
+    domain_of:
+    - CoordinateSystem
+    range: Axis
+    required: true
+    multivalued: true
+
+```
+</details>

--- a/docs/CoordinateTransformation.md
+++ b/docs/CoordinateTransformation.md
@@ -1,0 +1,250 @@
+
+
+# Class: CoordinateTransformation
+
+
+_A coordinate transformation_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:CoordinateTransformation](https://w3id.org/cetmd/entities/:CoordinateTransformation)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class CoordinateTransformation
+    click CoordinateTransformation href "../CoordinateTransformation"
+      CoordinateTransformation <|-- Identity
+        click Identity href "../Identity"
+      CoordinateTransformation <|-- MapAxis
+        click MapAxis href "../MapAxis"
+      CoordinateTransformation <|-- Translation
+        click Translation href "../Translation"
+      CoordinateTransformation <|-- Scale
+        click Scale href "../Scale"
+      CoordinateTransformation <|-- Affine
+        click Affine href "../Affine"
+      CoordinateTransformation <|-- Sequence
+        click Sequence href "../Sequence"
+      
+      CoordinateTransformation : input
+        
+      CoordinateTransformation : name
+        
+      CoordinateTransformation : output
+        
+      CoordinateTransformation : transformation_type
+        
+          
+    
+    
+    CoordinateTransformation --> "0..1" TransformationType : transformation_type
+    click TransformationType href "../TransformationType"
+
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* **CoordinateTransformation**
+    * [Identity](Identity.md)
+    * [MapAxis](MapAxis.md)
+    * [Translation](Translation.md)
+    * [Scale](Scale.md)
+    * [Affine](Affine.md)
+    * [Sequence](Sequence.md)
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [transformation_type](transformation_type.md) | 0..1 <br/> [TransformationType](TransformationType.md) | The type of transformation | direct |
+| [name](name.md) | 0..1 <br/> [String](String.md) | The name of the coordinate transformation | direct |
+| [input](input.md) | 0..1 <br/> [String](String.md) | The source coordinate system name | direct |
+| [output](output.md) | 0..1 <br/> [String](String.md) | The target coordinate system name | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [Image2D](Image2D.md) | [coordinate_transformations](coordinate_transformations.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [Image3D](Image3D.md) | [coordinate_transformations](coordinate_transformations.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [Sequence](Sequence.md) | [sequence](sequence.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [GainFile](GainFile.md) | [coordinate_transformations](coordinate_transformations.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [DefectFile](DefectFile.md) | [coordinate_transformations](coordinate_transformations.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [MovieFrame](MovieFrame.md) | [coordinate_transformations](coordinate_transformations.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [ProjectionImage](ProjectionImage.md) | [coordinate_transformations](coordinate_transformations.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [SubProjectionImage](SubProjectionImage.md) | [coordinate_transformations](coordinate_transformations.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [Tomogram](Tomogram.md) | [coordinate_transformations](coordinate_transformations.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [ParticleMap](ParticleMap.md) | [coordinate_transformations](coordinate_transformations.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [CoordMetaMixin](CoordMetaMixin.md) | [coordinate_transformations](coordinate_transformations.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [SegmentationMask2D](SegmentationMask2D.md) | [coordinate_transformations](coordinate_transformations.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [SegmentationMask3D](SegmentationMask3D.md) | [coordinate_transformations](coordinate_transformations.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [ProbabilityMap2D](ProbabilityMap2D.md) | [coordinate_transformations](coordinate_transformations.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [ProbabilityMap3D](ProbabilityMap3D.md) | [coordinate_transformations](coordinate_transformations.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [PointSet2D](PointSet2D.md) | [coordinate_transformations](coordinate_transformations.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [PointSet3D](PointSet3D.md) | [coordinate_transformations](coordinate_transformations.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [PointVectorSet2D](PointVectorSet2D.md) | [coordinate_transformations](coordinate_transformations.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [PointVectorSet3D](PointVectorSet3D.md) | [coordinate_transformations](coordinate_transformations.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [PointMatrixSet2D](PointMatrixSet2D.md) | [coordinate_transformations](coordinate_transformations.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [PointMatrixSet3D](PointMatrixSet3D.md) | [coordinate_transformations](coordinate_transformations.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [TriMesh](TriMesh.md) | [coordinate_transformations](coordinate_transformations.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+| [ProjectionAlignment](ProjectionAlignment.md) | [sequence](sequence.md) | range | [CoordinateTransformation](CoordinateTransformation.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:CoordinateTransformation |
+| native | https://w3id.org/cetmd/entities/:CoordinateTransformation |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: CoordinateTransformation
+description: A coordinate transformation
+from_schema: https://w3id.org/cetmd/entities
+slots:
+- transformation_type
+attributes:
+  name:
+    name: name
+    description: The name of the coordinate transformation
+    from_schema: https://w3id.org/cetmd/coord_transforms
+    domain_of:
+    - Average
+    - Dataset
+    - CoordinateSystem
+    - CoordinateTransformation
+    range: string
+  input:
+    name: input
+    description: The source coordinate system name
+    from_schema: https://w3id.org/cetmd/coord_transforms
+    rank: 1000
+    domain_of:
+    - CoordinateTransformation
+    - ProjectionAlignment
+    range: string
+  output:
+    name: output
+    description: The target coordinate system name
+    from_schema: https://w3id.org/cetmd/coord_transforms
+    rank: 1000
+    domain_of:
+    - CoordinateTransformation
+    - ProjectionAlignment
+    range: string
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: CoordinateTransformation
+description: A coordinate transformation
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  name:
+    name: name
+    description: The name of the coordinate transformation
+    from_schema: https://w3id.org/cetmd/coord_transforms
+    alias: name
+    owner: CoordinateTransformation
+    domain_of:
+    - Average
+    - Dataset
+    - CoordinateSystem
+    - CoordinateTransformation
+    range: string
+  input:
+    name: input
+    description: The source coordinate system name
+    from_schema: https://w3id.org/cetmd/coord_transforms
+    rank: 1000
+    alias: input
+    owner: CoordinateTransformation
+    domain_of:
+    - CoordinateTransformation
+    - ProjectionAlignment
+    range: string
+  output:
+    name: output
+    description: The target coordinate system name
+    from_schema: https://w3id.org/cetmd/coord_transforms
+    rank: 1000
+    alias: output
+    owner: CoordinateTransformation
+    domain_of:
+    - CoordinateTransformation
+    - ProjectionAlignment
+    range: string
+  transformation_type:
+    name: transformation_type
+    description: The type of transformation
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: transformation_type
+    owner: CoordinateTransformation
+    domain_of:
+    - CoordinateTransformation
+    - Identity
+    - MapAxis
+    - Translation
+    - Scale
+    - Affine
+    - Sequence
+    range: TransformationType
+
+```
+</details>

--- a/docs/Curie.md
+++ b/docs/Curie.md
@@ -1,0 +1,54 @@
+# Type: Curie
+
+
+
+
+_a compact URI_
+
+
+
+URI: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+* [base](https://w3id.org/linkml/base): Curie
+
+* [uri](https://w3id.org/linkml/uri): xsd:string
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Comments
+
+* in RDF serializations this MUST be expanded to a URI
+* in non-RDF serializations MAY be serialized as the compact representation
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:string |
+| native | https://w3id.org/cetmd/entities/:curie |
+
+
+

--- a/docs/Dataset.md
+++ b/docs/Dataset.md
@@ -1,0 +1,178 @@
+
+
+# Class: Dataset
+
+
+_A dataset_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:Dataset](https://w3id.org/cetmd/entities/:Dataset)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class Dataset
+    click Dataset href "../Dataset"
+      Dataset : averages
+        
+          
+    
+    
+    Dataset --> "*" Average : averages
+    click Average href "../Average"
+
+        
+      Dataset : name
+        
+      Dataset : regions
+        
+          
+    
+    
+    Dataset --> "*" Region : regions
+    click Region href "../Region"
+
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [name](name.md) | 0..1 <br/> [String](String.md) | The name of a given entry | direct |
+| [regions](regions.md) | * <br/> [Region](Region.md) | The regions in the dataset | direct |
+| [averages](averages.md) | * <br/> [Average](Average.md) | The averages in the dataset | direct |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:Dataset |
+| native | https://w3id.org/cetmd/entities/:Dataset |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: Dataset
+description: A dataset
+from_schema: https://w3id.org/cetmd/entities
+slots:
+- name
+attributes:
+  regions:
+    name: regions
+    description: The regions in the dataset
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    domain_of:
+    - Dataset
+    range: Region
+    multivalued: true
+  averages:
+    name: averages
+    description: The averages in the dataset
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    domain_of:
+    - Dataset
+    range: Average
+    multivalued: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: Dataset
+description: A dataset
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  regions:
+    name: regions
+    description: The regions in the dataset
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: regions
+    owner: Dataset
+    domain_of:
+    - Dataset
+    range: Region
+    multivalued: true
+  averages:
+    name: averages
+    description: The averages in the dataset
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: averages
+    owner: Dataset
+    domain_of:
+    - Dataset
+    range: Average
+    multivalued: true
+  name:
+    name: name
+    description: The name of a given entry
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: name
+    owner: Dataset
+    domain_of:
+    - Average
+    - Dataset
+    - CoordinateSystem
+    - CoordinateTransformation
+    range: string
+
+```
+</details>

--- a/docs/Date.md
+++ b/docs/Date.md
@@ -1,0 +1,50 @@
+# Type: Date
+
+
+
+
+_a date (year, month and day) in an idealized calendar_
+
+
+
+URI: [xsd:date](http://www.w3.org/2001/XMLSchema#date)
+
+* [base](https://w3id.org/linkml/base): XSDDate
+
+* [uri](https://w3id.org/linkml/uri): xsd:date
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:date |
+| native | https://w3id.org/cetmd/entities/:date |
+| exact | schema:Date |
+
+
+

--- a/docs/DateOrDatetime.md
+++ b/docs/DateOrDatetime.md
@@ -1,0 +1,49 @@
+# Type: DateOrDatetime
+
+
+
+
+_Either a date or a datetime_
+
+
+
+URI: [linkml:DateOrDatetime](https://w3id.org/linkml/DateOrDatetime)
+
+* [base](https://w3id.org/linkml/base): str
+
+* [uri](https://w3id.org/linkml/uri): linkml:DateOrDatetime
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | linkml:DateOrDatetime |
+| native | https://w3id.org/cetmd/entities/:date_or_datetime |
+
+
+

--- a/docs/Datetime.md
+++ b/docs/Datetime.md
@@ -1,0 +1,50 @@
+# Type: Datetime
+
+
+
+
+_The combination of a date and time_
+
+
+
+URI: [xsd:dateTime](http://www.w3.org/2001/XMLSchema#dateTime)
+
+* [base](https://w3id.org/linkml/base): XSDDateTime
+
+* [uri](https://w3id.org/linkml/uri): xsd:dateTime
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:dateTime |
+| native | https://w3id.org/cetmd/entities/:datetime |
+| exact | schema:DateTime |
+
+
+

--- a/docs/Decimal.md
+++ b/docs/Decimal.md
@@ -1,0 +1,49 @@
+# Type: Decimal
+
+
+
+
+_A real number with arbitrary precision that conforms to the xsd:decimal specification_
+
+
+
+URI: [xsd:decimal](http://www.w3.org/2001/XMLSchema#decimal)
+
+* [base](https://w3id.org/linkml/base): Decimal
+
+* [uri](https://w3id.org/linkml/uri): xsd:decimal
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:decimal |
+| native | https://w3id.org/cetmd/entities/:decimal |
+| broad | schema:Number |
+
+
+

--- a/docs/DefectFile.md
+++ b/docs/DefectFile.md
@@ -1,0 +1,212 @@
+
+
+# Class: DefectFile
+
+
+_A detector defect file._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:DefectFile](https://w3id.org/cetmd/entities/:DefectFile)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class DefectFile
+    click DefectFile href "../DefectFile"
+      Image2D <|-- DefectFile
+        click Image2D href "../Image2D"
+      
+      DefectFile : coordinate_systems
+        
+          
+    
+    
+    DefectFile --> "*" CoordinateSystem : coordinate_systems
+    click CoordinateSystem href "../CoordinateSystem"
+
+        
+      DefectFile : coordinate_transformations
+        
+          
+    
+    
+    DefectFile --> "*" CoordinateTransformation : coordinate_transformations
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      DefectFile : height
+        
+      DefectFile : path
+        
+      DefectFile : width
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Image2D](Image2D.md)
+    * **DefectFile**
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [path](path.md) | 0..1 <br/> [String](String.md) | Path to a file | direct |
+| [width](width.md) | 0..1 <br/> [Integer](Integer.md) | The width of the image (x-axis) in pixels | [Image2D](Image2D.md) |
+| [height](height.md) | 0..1 <br/> [Integer](Integer.md) | The height of the image (y-axis) in pixels | [Image2D](Image2D.md) |
+| [coordinate_systems](coordinate_systems.md) | * <br/> [CoordinateSystem](CoordinateSystem.md) | Named coordinate systems for this entity | [Image2D](Image2D.md) |
+| [coordinate_transformations](coordinate_transformations.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md) | Named coordinate systems for this entity | [Image2D](Image2D.md) |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [MovieStackCollection](MovieStackCollection.md) | [defect_file](defect_file.md) | range | [DefectFile](DefectFile.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:DefectFile |
+| native | https://w3id.org/cetmd/entities/:DefectFile |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: DefectFile
+description: A detector defect file.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Image2D
+slots:
+- path
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: DefectFile
+description: A detector defect file.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Image2D
+attributes:
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: path
+    owner: DefectFile
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    range: string
+  width:
+    name: width
+    description: The width of the image (x-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: width
+    owner: DefectFile
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  height:
+    name: height
+    description: The height of the image (y-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: height
+    owner: DefectFile
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_systems
+    owner: DefectFile
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_transformations
+    owner: DefectFile
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateTransformation
+    multivalued: true
+
+```
+</details>

--- a/docs/Double.md
+++ b/docs/Double.md
@@ -1,0 +1,49 @@
+# Type: Double
+
+
+
+
+_A real number that conforms to the xsd:double specification_
+
+
+
+URI: [xsd:double](http://www.w3.org/2001/XMLSchema#double)
+
+* [base](https://w3id.org/linkml/base): float
+
+* [uri](https://w3id.org/linkml/uri): xsd:double
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:double |
+| native | https://w3id.org/cetmd/entities/:double |
+| close | schema:Float |
+
+
+

--- a/docs/Float.md
+++ b/docs/Float.md
@@ -1,0 +1,49 @@
+# Type: Float
+
+
+
+
+_A real number that conforms to the xsd:float specification_
+
+
+
+URI: [xsd:float](http://www.w3.org/2001/XMLSchema#float)
+
+* [base](https://w3id.org/linkml/base): float
+
+* [uri](https://w3id.org/linkml/uri): xsd:float
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:float |
+| native | https://w3id.org/cetmd/entities/:float |
+| exact | schema:Float |
+
+
+

--- a/docs/GainFile.md
+++ b/docs/GainFile.md
@@ -1,0 +1,212 @@
+
+
+# Class: GainFile
+
+
+_A gain reference file._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:GainFile](https://w3id.org/cetmd/entities/:GainFile)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class GainFile
+    click GainFile href "../GainFile"
+      Image2D <|-- GainFile
+        click Image2D href "../Image2D"
+      
+      GainFile : coordinate_systems
+        
+          
+    
+    
+    GainFile --> "*" CoordinateSystem : coordinate_systems
+    click CoordinateSystem href "../CoordinateSystem"
+
+        
+      GainFile : coordinate_transformations
+        
+          
+    
+    
+    GainFile --> "*" CoordinateTransformation : coordinate_transformations
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      GainFile : height
+        
+      GainFile : path
+        
+      GainFile : width
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Image2D](Image2D.md)
+    * **GainFile**
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [path](path.md) | 0..1 <br/> [String](String.md) | Path to a file | direct |
+| [width](width.md) | 0..1 <br/> [Integer](Integer.md) | The width of the image (x-axis) in pixels | [Image2D](Image2D.md) |
+| [height](height.md) | 0..1 <br/> [Integer](Integer.md) | The height of the image (y-axis) in pixels | [Image2D](Image2D.md) |
+| [coordinate_systems](coordinate_systems.md) | * <br/> [CoordinateSystem](CoordinateSystem.md) | Named coordinate systems for this entity | [Image2D](Image2D.md) |
+| [coordinate_transformations](coordinate_transformations.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md) | Named coordinate systems for this entity | [Image2D](Image2D.md) |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [MovieStackCollection](MovieStackCollection.md) | [gain_file](gain_file.md) | range | [GainFile](GainFile.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:GainFile |
+| native | https://w3id.org/cetmd/entities/:GainFile |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: GainFile
+description: A gain reference file.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Image2D
+slots:
+- path
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: GainFile
+description: A gain reference file.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Image2D
+attributes:
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: path
+    owner: GainFile
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    range: string
+  width:
+    name: width
+    description: The width of the image (x-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: width
+    owner: GainFile
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  height:
+    name: height
+    description: The height of the image (y-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: height
+    owner: GainFile
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_systems
+    owner: GainFile
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_transformations
+    owner: GainFile
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateTransformation
+    multivalued: true
+
+```
+</details>

--- a/docs/Identity.md
+++ b/docs/Identity.md
@@ -1,0 +1,188 @@
+
+
+# Class: Identity
+
+
+_The identity transformation_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:Identity](https://w3id.org/cetmd/entities/:Identity)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class Identity
+    click Identity href "../Identity"
+      CoordinateTransformation <|-- Identity
+        click CoordinateTransformation href "../CoordinateTransformation"
+      
+      Identity : input
+        
+      Identity : name
+        
+      Identity : output
+        
+      Identity : transformation_type
+        
+          
+    
+    
+    Identity --> "0..1" TransformationType : transformation_type
+    click TransformationType href "../TransformationType"
+
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [CoordinateTransformation](CoordinateTransformation.md)
+    * **Identity**
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [transformation_type](transformation_type.md) | 0..1 <br/> [TransformationType](TransformationType.md) | The type of transformation | direct |
+| [name](name.md) | 0..1 <br/> [String](String.md) | The name of the coordinate transformation | [CoordinateTransformation](CoordinateTransformation.md) |
+| [input](input.md) | 0..1 <br/> [String](String.md) | The source coordinate system name | [CoordinateTransformation](CoordinateTransformation.md) |
+| [output](output.md) | 0..1 <br/> [String](String.md) | The target coordinate system name | [CoordinateTransformation](CoordinateTransformation.md) |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:Identity |
+| native | https://w3id.org/cetmd/entities/:Identity |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: Identity
+description: The identity transformation
+from_schema: https://w3id.org/cetmd/entities
+is_a: CoordinateTransformation
+slots:
+- transformation_type
+slot_usage:
+  transformation_type:
+    name: transformation_type
+    ifabsent: identity
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: Identity
+description: The identity transformation
+from_schema: https://w3id.org/cetmd/entities
+is_a: CoordinateTransformation
+slot_usage:
+  transformation_type:
+    name: transformation_type
+    ifabsent: identity
+attributes:
+  transformation_type:
+    name: transformation_type
+    description: The type of transformation
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    ifabsent: identity
+    alias: transformation_type
+    owner: Identity
+    domain_of:
+    - CoordinateTransformation
+    - Identity
+    - MapAxis
+    - Translation
+    - Scale
+    - Affine
+    - Sequence
+    range: TransformationType
+  name:
+    name: name
+    description: The name of the coordinate transformation
+    from_schema: https://w3id.org/cetmd/coord_transforms
+    alias: name
+    owner: Identity
+    domain_of:
+    - Average
+    - Dataset
+    - CoordinateSystem
+    - CoordinateTransformation
+    range: string
+  input:
+    name: input
+    description: The source coordinate system name
+    from_schema: https://w3id.org/cetmd/coord_transforms
+    rank: 1000
+    alias: input
+    owner: Identity
+    domain_of:
+    - CoordinateTransformation
+    - ProjectionAlignment
+    range: string
+  output:
+    name: output
+    description: The target coordinate system name
+    from_schema: https://w3id.org/cetmd/coord_transforms
+    rank: 1000
+    alias: output
+    owner: Identity
+    domain_of:
+    - CoordinateTransformation
+    - ProjectionAlignment
+    range: string
+
+```
+</details>

--- a/docs/Image2D.md
+++ b/docs/Image2D.md
@@ -1,0 +1,205 @@
+
+
+# Class: Image2D
+
+
+_A 2D image._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:Image2D](https://w3id.org/cetmd/entities/:Image2D)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class Image2D
+    click Image2D href "../Image2D"
+      Image2D <|-- GainFile
+        click GainFile href "../GainFile"
+      Image2D <|-- DefectFile
+        click DefectFile href "../DefectFile"
+      Image2D <|-- MovieFrame
+        click MovieFrame href "../MovieFrame"
+      Image2D <|-- ProjectionImage
+        click ProjectionImage href "../ProjectionImage"
+      Image2D <|-- SegmentationMask2D
+        click SegmentationMask2D href "../SegmentationMask2D"
+      Image2D <|-- ProbabilityMap2D
+        click ProbabilityMap2D href "../ProbabilityMap2D"
+      
+      Image2D : coordinate_systems
+        
+          
+    
+    
+    Image2D --> "*" CoordinateSystem : coordinate_systems
+    click CoordinateSystem href "../CoordinateSystem"
+
+        
+      Image2D : coordinate_transformations
+        
+          
+    
+    
+    Image2D --> "*" CoordinateTransformation : coordinate_transformations
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      Image2D : height
+        
+      Image2D : width
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* **Image2D**
+    * [GainFile](GainFile.md)
+    * [DefectFile](DefectFile.md)
+    * [MovieFrame](MovieFrame.md) [ [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md)]
+    * [ProjectionImage](ProjectionImage.md) [ [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md)]
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [width](width.md) | 0..1 <br/> [Integer](Integer.md) | The width of the image (x-axis) in pixels | direct |
+| [height](height.md) | 0..1 <br/> [Integer](Integer.md) | The height of the image (y-axis) in pixels | direct |
+| [coordinate_systems](coordinate_systems.md) | * <br/> [CoordinateSystem](CoordinateSystem.md) | Named coordinate systems for this entity | direct |
+| [coordinate_transformations](coordinate_transformations.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md) | Named coordinate systems for this entity | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [ImageStack2D](ImageStack2D.md) | [images2D](images2D.md) | range | [Image2D](Image2D.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:Image2D |
+| native | https://w3id.org/cetmd/entities/:Image2D |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: Image2D
+description: A 2D image.
+from_schema: https://w3id.org/cetmd/entities
+slots:
+- width
+- height
+- coordinate_systems
+- coordinate_transformations
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: Image2D
+description: A 2D image.
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  width:
+    name: width
+    description: The width of the image (x-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: width
+    owner: Image2D
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  height:
+    name: height
+    description: The height of the image (y-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: height
+    owner: Image2D
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_systems
+    owner: Image2D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_transformations
+    owner: Image2D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateTransformation
+    multivalued: true
+
+```
+</details>

--- a/docs/Image3D.md
+++ b/docs/Image3D.md
@@ -1,0 +1,213 @@
+
+
+# Class: Image3D
+
+
+_A 3D image._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:Image3D](https://w3id.org/cetmd/entities/:Image3D)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class Image3D
+    click Image3D href "../Image3D"
+      Image3D <|-- Tomogram
+        click Tomogram href "../Tomogram"
+      Image3D <|-- ParticleMap
+        click ParticleMap href "../ParticleMap"
+      Image3D <|-- SegmentationMask3D
+        click SegmentationMask3D href "../SegmentationMask3D"
+      Image3D <|-- ProbabilityMap3D
+        click ProbabilityMap3D href "../ProbabilityMap3D"
+      
+      Image3D : coordinate_systems
+        
+          
+    
+    
+    Image3D --> "*" CoordinateSystem : coordinate_systems
+    click CoordinateSystem href "../CoordinateSystem"
+
+        
+      Image3D : coordinate_transformations
+        
+          
+    
+    
+    Image3D --> "*" CoordinateTransformation : coordinate_transformations
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      Image3D : depth
+        
+      Image3D : height
+        
+      Image3D : width
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* **Image3D**
+    * [Tomogram](Tomogram.md)
+    * [ParticleMap](ParticleMap.md)
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [width](width.md) | 0..1 <br/> [Integer](Integer.md) | The width of the image (x-axis) in pixels | direct |
+| [height](height.md) | 0..1 <br/> [Integer](Integer.md) | The height of the image (y-axis) in pixels | direct |
+| [depth](depth.md) | 0..1 <br/> [Integer](Integer.md) | The depth of the image (z-axis) in pixels | direct |
+| [coordinate_systems](coordinate_systems.md) | * <br/> [CoordinateSystem](CoordinateSystem.md) | Named coordinate systems for this entity | direct |
+| [coordinate_transformations](coordinate_transformations.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md) | Named coordinate systems for this entity | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [ImageStack3D](ImageStack3D.md) | [images3D](images3D.md) | range | [Image3D](Image3D.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:Image3D |
+| native | https://w3id.org/cetmd/entities/:Image3D |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: Image3D
+description: A 3D image.
+from_schema: https://w3id.org/cetmd/entities
+slots:
+- width
+- height
+- depth
+- coordinate_systems
+- coordinate_transformations
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: Image3D
+description: A 3D image.
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  width:
+    name: width
+    description: The width of the image (x-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: width
+    owner: Image3D
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  height:
+    name: height
+    description: The height of the image (y-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: height
+    owner: Image3D
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  depth:
+    name: depth
+    description: The depth of the image (z-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: depth
+    owner: Image3D
+    domain_of:
+    - Image3D
+    range: integer
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_systems
+    owner: Image3D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_transformations
+    owner: Image3D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateTransformation
+    multivalued: true
+
+```
+</details>

--- a/docs/ImageStack2D.md
+++ b/docs/ImageStack2D.md
@@ -1,0 +1,122 @@
+
+
+# Class: ImageStack2D
+
+
+_A stack of 2D images._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:ImageStack2D](https://w3id.org/cetmd/entities/:ImageStack2D)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class ImageStack2D
+    click ImageStack2D href "../ImageStack2D"
+      ImageStack2D : images2D
+        
+          
+    
+    
+    ImageStack2D --> "*" Image2D : images2D
+    click Image2D href "../Image2D"
+
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [images2D](images2D.md) | * <br/> [Image2D](Image2D.md) | The images in the stack | direct |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:ImageStack2D |
+| native | https://w3id.org/cetmd/entities/:ImageStack2D |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: ImageStack2D
+description: A stack of 2D images.
+from_schema: https://w3id.org/cetmd/entities
+slots:
+- images2D
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: ImageStack2D
+description: A stack of 2D images.
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  images2D:
+    name: images2D
+    description: The images in the stack
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: images2D
+    owner: ImageStack2D
+    domain_of:
+    - ImageStack2D
+    range: Image2D
+    multivalued: true
+
+```
+</details>

--- a/docs/ImageStack3D.md
+++ b/docs/ImageStack3D.md
@@ -1,0 +1,122 @@
+
+
+# Class: ImageStack3D
+
+
+_A stack of 3D images._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:ImageStack3D](https://w3id.org/cetmd/entities/:ImageStack3D)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class ImageStack3D
+    click ImageStack3D href "../ImageStack3D"
+      ImageStack3D : images3D
+        
+          
+    
+    
+    ImageStack3D --> "*" Image3D : images3D
+    click Image3D href "../Image3D"
+
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [images3D](images3D.md) | * <br/> [Image3D](Image3D.md) | The images in the stack | direct |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:ImageStack3D |
+| native | https://w3id.org/cetmd/entities/:ImageStack3D |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: ImageStack3D
+description: A stack of 3D images.
+from_schema: https://w3id.org/cetmd/entities
+slots:
+- images3D
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: ImageStack3D
+description: A stack of 3D images.
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  images3D:
+    name: images3D
+    description: The images in the stack
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: images3D
+    owner: ImageStack3D
+    domain_of:
+    - ImageStack3D
+    range: Image3D
+    multivalued: true
+
+```
+</details>

--- a/docs/Integer.md
+++ b/docs/Integer.md
@@ -1,0 +1,49 @@
+# Type: Integer
+
+
+
+
+_An integer_
+
+
+
+URI: [xsd:integer](http://www.w3.org/2001/XMLSchema#integer)
+
+* [base](https://w3id.org/linkml/base): int
+
+* [uri](https://w3id.org/linkml/uri): xsd:integer
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:integer |
+| native | https://w3id.org/cetmd/entities/:integer |
+| exact | schema:Integer |
+
+
+

--- a/docs/Jsonpath.md
+++ b/docs/Jsonpath.md
@@ -1,0 +1,49 @@
+# Type: Jsonpath
+
+
+
+
+_A string encoding a JSON Path. The value of the string MUST conform to JSON Point syntax and SHOULD dereference to zero or more valid objects within the current instance document when encoded in tree form._
+
+
+
+URI: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+* [base](https://w3id.org/linkml/base): str
+
+* [uri](https://w3id.org/linkml/uri): xsd:string
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:string |
+| native | https://w3id.org/cetmd/entities/:jsonpath |
+
+
+

--- a/docs/Jsonpointer.md
+++ b/docs/Jsonpointer.md
@@ -1,0 +1,49 @@
+# Type: Jsonpointer
+
+
+
+
+_A string encoding a JSON Pointer. The value of the string MUST conform to JSON Point syntax and SHOULD dereference to a valid object within the current instance document when encoded in tree form._
+
+
+
+URI: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+* [base](https://w3id.org/linkml/base): str
+
+* [uri](https://w3id.org/linkml/uri): xsd:string
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:string |
+| native | https://w3id.org/cetmd/entities/:jsonpointer |
+
+
+

--- a/docs/MapAxis.md
+++ b/docs/MapAxis.md
@@ -1,0 +1,221 @@
+
+
+# Class: MapAxis
+
+
+_Axis permutation transformation_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:MapAxis](https://w3id.org/cetmd/entities/:MapAxis)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class MapAxis
+    click MapAxis href "../MapAxis"
+      CoordinateTransformation <|-- MapAxis
+        click CoordinateTransformation href "../CoordinateTransformation"
+      
+      MapAxis : input
+        
+      MapAxis : map_axis
+        
+          
+    
+    
+    MapAxis --> "*" AxisNameMapping : map_axis
+    click AxisNameMapping href "../AxisNameMapping"
+
+        
+      MapAxis : name
+        
+      MapAxis : output
+        
+      MapAxis : transformation_type
+        
+          
+    
+    
+    MapAxis --> "0..1" TransformationType : transformation_type
+    click TransformationType href "../TransformationType"
+
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [CoordinateTransformation](CoordinateTransformation.md)
+    * **MapAxis**
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [transformation_type](transformation_type.md) | 0..1 <br/> [TransformationType](TransformationType.md) | The type of transformation | direct |
+| [map_axis](map_axis.md) | * <br/> [AxisNameMapping](AxisNameMapping.md) | The permutation of the axes | direct |
+| [name](name.md) | 0..1 <br/> [String](String.md) | The name of the coordinate transformation | [CoordinateTransformation](CoordinateTransformation.md) |
+| [input](input.md) | 0..1 <br/> [String](String.md) | The source coordinate system name | [CoordinateTransformation](CoordinateTransformation.md) |
+| [output](output.md) | 0..1 <br/> [String](String.md) | The target coordinate system name | [CoordinateTransformation](CoordinateTransformation.md) |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:MapAxis |
+| native | https://w3id.org/cetmd/entities/:MapAxis |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: MapAxis
+description: Axis permutation transformation
+from_schema: https://w3id.org/cetmd/entities
+is_a: CoordinateTransformation
+slots:
+- transformation_type
+slot_usage:
+  transformation_type:
+    name: transformation_type
+    ifabsent: map_axis
+attributes:
+  map_axis:
+    name: map_axis
+    description: The permutation of the axes
+    from_schema: https://w3id.org/cetmd/coord_transforms
+    rank: 1000
+    domain_of:
+    - MapAxis
+    range: AxisNameMapping
+    multivalued: true
+    inlined: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: MapAxis
+description: Axis permutation transformation
+from_schema: https://w3id.org/cetmd/entities
+is_a: CoordinateTransformation
+slot_usage:
+  transformation_type:
+    name: transformation_type
+    ifabsent: map_axis
+attributes:
+  map_axis:
+    name: map_axis
+    description: The permutation of the axes
+    from_schema: https://w3id.org/cetmd/coord_transforms
+    rank: 1000
+    alias: map_axis
+    owner: MapAxis
+    domain_of:
+    - MapAxis
+    range: AxisNameMapping
+    multivalued: true
+    inlined: true
+  transformation_type:
+    name: transformation_type
+    description: The type of transformation
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    ifabsent: map_axis
+    alias: transformation_type
+    owner: MapAxis
+    domain_of:
+    - CoordinateTransformation
+    - Identity
+    - MapAxis
+    - Translation
+    - Scale
+    - Affine
+    - Sequence
+    range: TransformationType
+  name:
+    name: name
+    description: The name of the coordinate transformation
+    from_schema: https://w3id.org/cetmd/coord_transforms
+    alias: name
+    owner: MapAxis
+    domain_of:
+    - Average
+    - Dataset
+    - CoordinateSystem
+    - CoordinateTransformation
+    range: string
+  input:
+    name: input
+    description: The source coordinate system name
+    from_schema: https://w3id.org/cetmd/coord_transforms
+    rank: 1000
+    alias: input
+    owner: MapAxis
+    domain_of:
+    - CoordinateTransformation
+    - ProjectionAlignment
+    range: string
+  output:
+    name: output
+    description: The target coordinate system name
+    from_schema: https://w3id.org/cetmd/coord_transforms
+    rank: 1000
+    alias: output
+    owner: MapAxis
+    domain_of:
+    - CoordinateTransformation
+    - ProjectionAlignment
+    range: string
+
+```
+</details>

--- a/docs/MovieFrame.md
+++ b/docs/MovieFrame.md
@@ -1,0 +1,279 @@
+
+
+# Class: MovieFrame
+
+
+_An individual movie frame_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:MovieFrame](https://w3id.org/cetmd/entities/:MovieFrame)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class MovieFrame
+    click MovieFrame href "../MovieFrame"
+      AcquisitionMetadataMixin <|-- MovieFrame
+        click AcquisitionMetadataMixin href "../AcquisitionMetadataMixin"
+      Image2D <|-- MovieFrame
+        click Image2D href "../Image2D"
+      
+      MovieFrame : accumulated_dose
+        
+      MovieFrame : coordinate_systems
+        
+          
+    
+    
+    MovieFrame --> "*" CoordinateSystem : coordinate_systems
+    click CoordinateSystem href "../CoordinateSystem"
+
+        
+      MovieFrame : coordinate_transformations
+        
+          
+    
+    
+    MovieFrame --> "*" CoordinateTransformation : coordinate_transformations
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      MovieFrame : ctf_metadata
+        
+          
+    
+    
+    MovieFrame --> "0..1" CTFMetadata : ctf_metadata
+    click CTFMetadata href "../CTFMetadata"
+
+        
+      MovieFrame : height
+        
+      MovieFrame : nominal_tilt_angle
+        
+      MovieFrame : path
+        
+      MovieFrame : section
+        
+      MovieFrame : width
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Image2D](Image2D.md)
+    * **MovieFrame** [ [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md)]
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [path](path.md) | 0..1 <br/> [String](String.md) | Path to a file | direct |
+| [section](section.md) | 0..1 <br/> [Integer](Integer.md) | 0-based section index to the entity inside a stack | direct |
+| [nominal_tilt_angle](nominal_tilt_angle.md) | 0..1 <br/> [Float](Float.md) | The tilt angle reported by the microscope | [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md) |
+| [accumulated_dose](accumulated_dose.md) | 0..1 <br/> [Float](Float.md) | The pre-exposure up to this image in e-/A^2 | [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md) |
+| [ctf_metadata](ctf_metadata.md) | 0..1 <br/> [CTFMetadata](CTFMetadata.md) | A set of CTF patameters for an image | [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md) |
+| [width](width.md) | 0..1 <br/> [Integer](Integer.md) | The width of the image (x-axis) in pixels | [Image2D](Image2D.md) |
+| [height](height.md) | 0..1 <br/> [Integer](Integer.md) | The height of the image (y-axis) in pixels | [Image2D](Image2D.md) |
+| [coordinate_systems](coordinate_systems.md) | * <br/> [CoordinateSystem](CoordinateSystem.md) | Named coordinate systems for this entity | [Image2D](Image2D.md) |
+| [coordinate_transformations](coordinate_transformations.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md) | Named coordinate systems for this entity | [Image2D](Image2D.md) |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [MovieStack](MovieStack.md) | [images_movie](images_movie.md) | range | [MovieFrame](MovieFrame.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:MovieFrame |
+| native | https://w3id.org/cetmd/entities/:MovieFrame |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: MovieFrame
+description: An individual movie frame
+from_schema: https://w3id.org/cetmd/entities
+is_a: Image2D
+mixins:
+- AcquisitionMetadataMixin
+slots:
+- path
+- section
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: MovieFrame
+description: An individual movie frame
+from_schema: https://w3id.org/cetmd/entities
+is_a: Image2D
+mixins:
+- AcquisitionMetadataMixin
+attributes:
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: path
+    owner: MovieFrame
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    range: string
+  section:
+    name: section
+    description: 0-based section index to the entity inside a stack.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: section
+    owner: MovieFrame
+    domain_of:
+    - MovieFrame
+    - ProjectionImage
+    range: integer
+  nominal_tilt_angle:
+    name: nominal_tilt_angle
+    description: The tilt angle reported by the microscope
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: nominal_tilt_angle
+    owner: MovieFrame
+    domain_of:
+    - AcquisitionMetadataMixin
+    range: float
+  accumulated_dose:
+    name: accumulated_dose
+    description: The pre-exposure up to this image in e-/A^2
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: accumulated_dose
+    owner: MovieFrame
+    domain_of:
+    - AcquisitionMetadataMixin
+    range: float
+  ctf_metadata:
+    name: ctf_metadata
+    description: A set of CTF patameters for an image.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: ctf_metadata
+    owner: MovieFrame
+    domain_of:
+    - AcquisitionMetadataMixin
+    range: CTFMetadata
+  width:
+    name: width
+    description: The width of the image (x-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: width
+    owner: MovieFrame
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  height:
+    name: height
+    description: The height of the image (y-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: height
+    owner: MovieFrame
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_systems
+    owner: MovieFrame
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_transformations
+    owner: MovieFrame
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateTransformation
+    multivalued: true
+
+```
+</details>

--- a/docs/MovieStack.md
+++ b/docs/MovieStack.md
@@ -1,0 +1,151 @@
+
+
+# Class: MovieStack
+
+
+_A stack of movie frames._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:MovieStack](https://w3id.org/cetmd/entities/:MovieStack)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class MovieStack
+    click MovieStack href "../MovieStack"
+      MovieStack : images_movie
+        
+          
+    
+    
+    MovieStack --> "*" MovieFrame : images_movie
+    click MovieFrame href "../MovieFrame"
+
+        
+      MovieStack : path
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [path](path.md) | 0..1 <br/> [String](String.md) | Path to a file | direct |
+| [images_movie](images_movie.md) | * <br/> [MovieFrame](MovieFrame.md) | The movie frames in the stack | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [MovieStackSeries](MovieStackSeries.md) | [stacks](stacks.md) | range | [MovieStack](MovieStack.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:MovieStack |
+| native | https://w3id.org/cetmd/entities/:MovieStack |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: MovieStack
+description: A stack of movie frames.
+from_schema: https://w3id.org/cetmd/entities
+slots:
+- path
+- images_movie
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: MovieStack
+description: A stack of movie frames.
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: path
+    owner: MovieStack
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    range: string
+  images_movie:
+    name: images_movie
+    description: The movie frames in the stack
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: images_movie
+    owner: MovieStack
+    domain_of:
+    - MovieStack
+    range: MovieFrame
+    multivalued: true
+
+```
+</details>

--- a/docs/MovieStackCollection.md
+++ b/docs/MovieStackCollection.md
@@ -1,0 +1,193 @@
+
+
+# Class: MovieStackCollection
+
+
+_A collection of movie stacks using the same gain and defect files._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:MovieStackCollection](https://w3id.org/cetmd/entities/:MovieStackCollection)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class MovieStackCollection
+    click MovieStackCollection href "../MovieStackCollection"
+      MovieStackCollection : defect_file
+        
+          
+    
+    
+    MovieStackCollection --> "0..1" DefectFile : defect_file
+    click DefectFile href "../DefectFile"
+
+        
+      MovieStackCollection : gain_file
+        
+          
+    
+    
+    MovieStackCollection --> "0..1" GainFile : gain_file
+    click GainFile href "../GainFile"
+
+        
+      MovieStackCollection : movie_stacks
+        
+          
+    
+    
+    MovieStackCollection --> "*" MovieStackSeries : movie_stacks
+    click MovieStackSeries href "../MovieStackSeries"
+
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [movie_stacks](movie_stacks.md) | * <br/> [MovieStackSeries](MovieStackSeries.md) | The movie stacks in the collection | direct |
+| [gain_file](gain_file.md) | 0..1 <br/> [GainFile](GainFile.md) | The gain file for the movie stacks | direct |
+| [defect_file](defect_file.md) | 0..1 <br/> [DefectFile](DefectFile.md) | The defect file for the movie stacks | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [Region](Region.md) | [movie_stack_collections](movie_stack_collections.md) | range | [MovieStackCollection](MovieStackCollection.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:MovieStackCollection |
+| native | https://w3id.org/cetmd/entities/:MovieStackCollection |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: MovieStackCollection
+description: A collection of movie stacks using the same gain and defect files.
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  movie_stacks:
+    name: movie_stacks
+    description: The movie stacks in the collection
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    domain_of:
+    - MovieStackCollection
+    range: MovieStackSeries
+    multivalued: true
+  gain_file:
+    name: gain_file
+    description: The gain file for the movie stacks
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    domain_of:
+    - MovieStackCollection
+    range: GainFile
+  defect_file:
+    name: defect_file
+    description: The defect file for the movie stacks
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    domain_of:
+    - MovieStackCollection
+    range: DefectFile
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: MovieStackCollection
+description: A collection of movie stacks using the same gain and defect files.
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  movie_stacks:
+    name: movie_stacks
+    description: The movie stacks in the collection
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: movie_stacks
+    owner: MovieStackCollection
+    domain_of:
+    - MovieStackCollection
+    range: MovieStackSeries
+    multivalued: true
+  gain_file:
+    name: gain_file
+    description: The gain file for the movie stacks
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: gain_file
+    owner: MovieStackCollection
+    domain_of:
+    - MovieStackCollection
+    range: GainFile
+  defect_file:
+    name: defect_file
+    description: The defect file for the movie stacks
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: defect_file
+    owner: MovieStackCollection
+    domain_of:
+    - MovieStackCollection
+    range: DefectFile
+
+```
+</details>

--- a/docs/MovieStackSeries.md
+++ b/docs/MovieStackSeries.md
@@ -1,0 +1,137 @@
+
+
+# Class: MovieStackSeries
+
+
+_A group of movie stacks that belong to a single tilt series._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:MovieStackSeries](https://w3id.org/cetmd/entities/:MovieStackSeries)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class MovieStackSeries
+    click MovieStackSeries href "../MovieStackSeries"
+      MovieStackSeries : stacks
+        
+          
+    
+    
+    MovieStackSeries --> "*" MovieStack : stacks
+    click MovieStack href "../MovieStack"
+
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [stacks](stacks.md) | * <br/> [MovieStack](MovieStack.md) | The movie stacks | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [MovieStackCollection](MovieStackCollection.md) | [movie_stacks](movie_stacks.md) | range | [MovieStackSeries](MovieStackSeries.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:MovieStackSeries |
+| native | https://w3id.org/cetmd/entities/:MovieStackSeries |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: MovieStackSeries
+description: A group of movie stacks that belong to a single tilt series.
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  stacks:
+    name: stacks
+    description: The movie stacks.
+    from_schema: https://w3id.org/cetmd/image_entities
+    rank: 1000
+    domain_of:
+    - MovieStackSeries
+    range: MovieStack
+    multivalued: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: MovieStackSeries
+description: A group of movie stacks that belong to a single tilt series.
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  stacks:
+    name: stacks
+    description: The movie stacks.
+    from_schema: https://w3id.org/cetmd/image_entities
+    rank: 1000
+    alias: stacks
+    owner: MovieStackSeries
+    domain_of:
+    - MovieStackSeries
+    range: MovieStack
+    multivalued: true
+
+```
+</details>

--- a/docs/Ncname.md
+++ b/docs/Ncname.md
@@ -1,0 +1,49 @@
+# Type: Ncname
+
+
+
+
+_Prefix part of CURIE_
+
+
+
+URI: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+* [base](https://w3id.org/linkml/base): NCName
+
+* [uri](https://w3id.org/linkml/uri): xsd:string
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:string |
+| native | https://w3id.org/cetmd/entities/:ncname |
+
+
+

--- a/docs/Nodeidentifier.md
+++ b/docs/Nodeidentifier.md
@@ -1,0 +1,49 @@
+# Type: Nodeidentifier
+
+
+
+
+_A URI, CURIE or BNODE that represents a node in a model._
+
+
+
+URI: [shex:nonLiteral](http://www.w3.org/ns/shex#nonLiteral)
+
+* [base](https://w3id.org/linkml/base): NodeIdentifier
+
+* [uri](https://w3id.org/linkml/uri): shex:nonLiteral
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | shex:nonLiteral |
+| native | https://w3id.org/cetmd/entities/:nodeidentifier |
+
+
+

--- a/docs/Objectidentifier.md
+++ b/docs/Objectidentifier.md
@@ -1,0 +1,53 @@
+# Type: Objectidentifier
+
+
+
+
+_A URI or CURIE that represents an object in the model._
+
+
+
+URI: [shex:iri](http://www.w3.org/ns/shex#iri)
+
+* [base](https://w3id.org/linkml/base): ElementIdentifier
+
+* [uri](https://w3id.org/linkml/uri): shex:iri
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Comments
+
+* Used for inheritance and type checking
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | shex:iri |
+| native | https://w3id.org/cetmd/entities/:objectidentifier |
+
+
+

--- a/docs/ParticleMap.md
+++ b/docs/ParticleMap.md
@@ -1,0 +1,225 @@
+
+
+# Class: ParticleMap
+
+
+_A 3D particle density map._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:ParticleMap](https://w3id.org/cetmd/entities/:ParticleMap)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class ParticleMap
+    click ParticleMap href "../ParticleMap"
+      Image3D <|-- ParticleMap
+        click Image3D href "../Image3D"
+      
+      ParticleMap : coordinate_systems
+        
+          
+    
+    
+    ParticleMap --> "*" CoordinateSystem : coordinate_systems
+    click CoordinateSystem href "../CoordinateSystem"
+
+        
+      ParticleMap : coordinate_transformations
+        
+          
+    
+    
+    ParticleMap --> "*" CoordinateTransformation : coordinate_transformations
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      ParticleMap : depth
+        
+      ParticleMap : height
+        
+      ParticleMap : path
+        
+      ParticleMap : width
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Image3D](Image3D.md)
+    * **ParticleMap**
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [path](path.md) | 0..1 <br/> [String](String.md) | Path to a file | direct |
+| [width](width.md) | 0..1 <br/> [Integer](Integer.md) | The width of the image (x-axis) in pixels | [Image3D](Image3D.md) |
+| [height](height.md) | 0..1 <br/> [Integer](Integer.md) | The height of the image (y-axis) in pixels | [Image3D](Image3D.md) |
+| [depth](depth.md) | 0..1 <br/> [Integer](Integer.md) | The depth of the image (z-axis) in pixels | [Image3D](Image3D.md) |
+| [coordinate_systems](coordinate_systems.md) | * <br/> [CoordinateSystem](CoordinateSystem.md) | Named coordinate systems for this entity | [Image3D](Image3D.md) |
+| [coordinate_transformations](coordinate_transformations.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md) | Named coordinate systems for this entity | [Image3D](Image3D.md) |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [Average](Average.md) | [particle_maps](particle_maps.md) | range | [ParticleMap](ParticleMap.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:ParticleMap |
+| native | https://w3id.org/cetmd/entities/:ParticleMap |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: ParticleMap
+description: A 3D particle density map.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Image3D
+slots:
+- path
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: ParticleMap
+description: A 3D particle density map.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Image3D
+attributes:
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: path
+    owner: ParticleMap
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    range: string
+  width:
+    name: width
+    description: The width of the image (x-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: width
+    owner: ParticleMap
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  height:
+    name: height
+    description: The height of the image (y-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: height
+    owner: ParticleMap
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  depth:
+    name: depth
+    description: The depth of the image (z-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: depth
+    owner: ParticleMap
+    domain_of:
+    - Image3D
+    range: integer
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_systems
+    owner: ParticleMap
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_transformations
+    owner: ParticleMap
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateTransformation
+    multivalued: true
+
+```
+</details>

--- a/docs/PointMatrixSet2D.md
+++ b/docs/PointMatrixSet2D.md
@@ -1,0 +1,228 @@
+
+
+# Class: PointMatrixSet2D
+
+
+_A set of 2D points with an associated rotation matrix._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:PointMatrixSet2D](https://w3id.org/cetmd/entities/:PointMatrixSet2D)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class PointMatrixSet2D
+    click PointMatrixSet2D href "../PointMatrixSet2D"
+      CoordMetaMixin <|-- PointMatrixSet2D
+        click CoordMetaMixin href "../CoordMetaMixin"
+      Annotation <|-- PointMatrixSet2D
+        click Annotation href "../Annotation"
+      
+      PointMatrixSet2D : coordinate_systems
+        
+          
+    
+    
+    PointMatrixSet2D --> "*" CoordinateSystem : coordinate_systems
+    click CoordinateSystem href "../CoordinateSystem"
+
+        
+      PointMatrixSet2D : coordinate_transformations
+        
+          
+    
+    
+    PointMatrixSet2D --> "*" CoordinateTransformation : coordinate_transformations
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      PointMatrixSet2D : matrix2D
+        
+      PointMatrixSet2D : origin2D
+        
+      PointMatrixSet2D : path
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Annotation](Annotation.md)
+    * **PointMatrixSet2D** [ [CoordMetaMixin](CoordMetaMixin.md)]
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [origin2D](origin2D.md) | 0..1 <br/> [Float](Float.md) | Location on a 2D image (Nx2) | direct |
+| [matrix2D](matrix2D.md) | 0..1 <br/> [Float](Float.md) | Rotation matrix associated with a point on a 2D image (Nx2x2) | direct |
+| [coordinate_systems](coordinate_systems.md) | * <br/> [CoordinateSystem](CoordinateSystem.md) | Named coordinate systems for this entity | [CoordMetaMixin](CoordMetaMixin.md) |
+| [coordinate_transformations](coordinate_transformations.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md) | Named coordinate systems for this entity | [CoordMetaMixin](CoordMetaMixin.md) |
+| [path](path.md) | 0..1 <br/> [String](String.md) | Path to a file | [Annotation](Annotation.md) |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:PointMatrixSet2D |
+| native | https://w3id.org/cetmd/entities/:PointMatrixSet2D |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: PointMatrixSet2D
+description: A set of 2D points with an associated rotation matrix.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- CoordMetaMixin
+slots:
+- origin2D
+- matrix2D
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: PointMatrixSet2D
+description: A set of 2D points with an associated rotation matrix.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- CoordMetaMixin
+attributes:
+  origin2D:
+    name: origin2D
+    description: Location on a 2D image (Nx2).
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    array:
+      exact_number_dimensions: 2
+      dimensions:
+      - alias: N
+        minimum_cardinality: 1
+      - alias: xy
+        exact_cardinality: 2
+    alias: origin2D
+    owner: PointMatrixSet2D
+    domain_of:
+    - PointSet2D
+    - PointVectorSet2D
+    - PointMatrixSet2D
+    range: float
+  matrix2D:
+    name: matrix2D
+    description: Rotation matrix associated with a point on a 2D image (Nx2x2).
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    array:
+      exact_number_dimensions: 3
+      dimensions:
+      - alias: N
+        minimum_cardinality: 1
+      - alias: xy
+        exact_cardinality: 2
+      - alias: xy
+        exact_cardinality: 2
+    alias: matrix2D
+    owner: PointMatrixSet2D
+    domain_of:
+    - PointMatrixSet2D
+    range: float
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_systems
+    owner: PointMatrixSet2D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_transformations
+    owner: PointMatrixSet2D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateTransformation
+    multivalued: true
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: path
+    owner: PointMatrixSet2D
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    range: string
+
+```
+</details>

--- a/docs/PointMatrixSet3D.md
+++ b/docs/PointMatrixSet3D.md
@@ -1,0 +1,228 @@
+
+
+# Class: PointMatrixSet3D
+
+
+_A set of 3D points with an associated rotation matrix._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:PointMatrixSet3D](https://w3id.org/cetmd/entities/:PointMatrixSet3D)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class PointMatrixSet3D
+    click PointMatrixSet3D href "../PointMatrixSet3D"
+      CoordMetaMixin <|-- PointMatrixSet3D
+        click CoordMetaMixin href "../CoordMetaMixin"
+      Annotation <|-- PointMatrixSet3D
+        click Annotation href "../Annotation"
+      
+      PointMatrixSet3D : coordinate_systems
+        
+          
+    
+    
+    PointMatrixSet3D --> "*" CoordinateSystem : coordinate_systems
+    click CoordinateSystem href "../CoordinateSystem"
+
+        
+      PointMatrixSet3D : coordinate_transformations
+        
+          
+    
+    
+    PointMatrixSet3D --> "*" CoordinateTransformation : coordinate_transformations
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      PointMatrixSet3D : matrix3D
+        
+      PointMatrixSet3D : origin3D
+        
+      PointMatrixSet3D : path
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Annotation](Annotation.md)
+    * **PointMatrixSet3D** [ [CoordMetaMixin](CoordMetaMixin.md)]
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [origin3D](origin3D.md) | 0..1 <br/> [Float](Float.md) | Location on a 3D image (Nx3) | direct |
+| [matrix3D](matrix3D.md) | 0..1 <br/> [Float](Float.md) | Rotation matrix associated with a point on a 3D image (Nx3x3) | direct |
+| [coordinate_systems](coordinate_systems.md) | * <br/> [CoordinateSystem](CoordinateSystem.md) | Named coordinate systems for this entity | [CoordMetaMixin](CoordMetaMixin.md) |
+| [coordinate_transformations](coordinate_transformations.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md) | Named coordinate systems for this entity | [CoordMetaMixin](CoordMetaMixin.md) |
+| [path](path.md) | 0..1 <br/> [String](String.md) | Path to a file | [Annotation](Annotation.md) |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:PointMatrixSet3D |
+| native | https://w3id.org/cetmd/entities/:PointMatrixSet3D |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: PointMatrixSet3D
+description: A set of 3D points with an associated rotation matrix.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- CoordMetaMixin
+slots:
+- origin3D
+- matrix3D
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: PointMatrixSet3D
+description: A set of 3D points with an associated rotation matrix.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- CoordMetaMixin
+attributes:
+  origin3D:
+    name: origin3D
+    description: Location on a 3D image (Nx3).
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    array:
+      exact_number_dimensions: 2
+      dimensions:
+      - alias: N
+        minimum_cardinality: 1
+      - alias: xyz
+        exact_cardinality: 3
+    alias: origin3D
+    owner: PointMatrixSet3D
+    domain_of:
+    - PointSet3D
+    - PointVectorSet3D
+    - PointMatrixSet3D
+    range: float
+  matrix3D:
+    name: matrix3D
+    description: Rotation matrix associated with a point on a 3D image (Nx3x3).
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    array:
+      exact_number_dimensions: 3
+      dimensions:
+      - alias: N
+        minimum_cardinality: 1
+      - alias: xyz
+        exact_cardinality: 3
+      - alias: xyz
+        exact_cardinality: 3
+    alias: matrix3D
+    owner: PointMatrixSet3D
+    domain_of:
+    - PointMatrixSet3D
+    range: float
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_systems
+    owner: PointMatrixSet3D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_transformations
+    owner: PointMatrixSet3D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateTransformation
+    multivalued: true
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: path
+    owner: PointMatrixSet3D
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    range: string
+
+```
+</details>

--- a/docs/PointSet2D.md
+++ b/docs/PointSet2D.md
@@ -1,0 +1,205 @@
+
+
+# Class: PointSet2D
+
+
+_A set of 2D point annotations._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:PointSet2D](https://w3id.org/cetmd/entities/:PointSet2D)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class PointSet2D
+    click PointSet2D href "../PointSet2D"
+      CoordMetaMixin <|-- PointSet2D
+        click CoordMetaMixin href "../CoordMetaMixin"
+      Annotation <|-- PointSet2D
+        click Annotation href "../Annotation"
+      
+      PointSet2D : coordinate_systems
+        
+          
+    
+    
+    PointSet2D --> "*" CoordinateSystem : coordinate_systems
+    click CoordinateSystem href "../CoordinateSystem"
+
+        
+      PointSet2D : coordinate_transformations
+        
+          
+    
+    
+    PointSet2D --> "*" CoordinateTransformation : coordinate_transformations
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      PointSet2D : origin2D
+        
+      PointSet2D : path
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Annotation](Annotation.md)
+    * **PointSet2D** [ [CoordMetaMixin](CoordMetaMixin.md)]
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [origin2D](origin2D.md) | 0..1 <br/> [Float](Float.md) | Location on a 2D image (Nx2) | direct |
+| [coordinate_systems](coordinate_systems.md) | * <br/> [CoordinateSystem](CoordinateSystem.md) | Named coordinate systems for this entity | [CoordMetaMixin](CoordMetaMixin.md) |
+| [coordinate_transformations](coordinate_transformations.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md) | Named coordinate systems for this entity | [CoordMetaMixin](CoordMetaMixin.md) |
+| [path](path.md) | 0..1 <br/> [String](String.md) | Path to a file | [Annotation](Annotation.md) |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:PointSet2D |
+| native | https://w3id.org/cetmd/entities/:PointSet2D |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: PointSet2D
+description: A set of 2D point annotations.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- CoordMetaMixin
+slots:
+- origin2D
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: PointSet2D
+description: A set of 2D point annotations.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- CoordMetaMixin
+attributes:
+  origin2D:
+    name: origin2D
+    description: Location on a 2D image (Nx2).
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    array:
+      exact_number_dimensions: 2
+      dimensions:
+      - alias: N
+        minimum_cardinality: 1
+      - alias: xy
+        exact_cardinality: 2
+    alias: origin2D
+    owner: PointSet2D
+    domain_of:
+    - PointSet2D
+    - PointVectorSet2D
+    - PointMatrixSet2D
+    range: float
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_systems
+    owner: PointSet2D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_transformations
+    owner: PointSet2D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateTransformation
+    multivalued: true
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: path
+    owner: PointSet2D
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    range: string
+
+```
+</details>

--- a/docs/PointSet3D.md
+++ b/docs/PointSet3D.md
@@ -1,0 +1,205 @@
+
+
+# Class: PointSet3D
+
+
+_A set of 3D point annotations._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:PointSet3D](https://w3id.org/cetmd/entities/:PointSet3D)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class PointSet3D
+    click PointSet3D href "../PointSet3D"
+      CoordMetaMixin <|-- PointSet3D
+        click CoordMetaMixin href "../CoordMetaMixin"
+      Annotation <|-- PointSet3D
+        click Annotation href "../Annotation"
+      
+      PointSet3D : coordinate_systems
+        
+          
+    
+    
+    PointSet3D --> "*" CoordinateSystem : coordinate_systems
+    click CoordinateSystem href "../CoordinateSystem"
+
+        
+      PointSet3D : coordinate_transformations
+        
+          
+    
+    
+    PointSet3D --> "*" CoordinateTransformation : coordinate_transformations
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      PointSet3D : origin3D
+        
+      PointSet3D : path
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Annotation](Annotation.md)
+    * **PointSet3D** [ [CoordMetaMixin](CoordMetaMixin.md)]
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [origin3D](origin3D.md) | 0..1 <br/> [Float](Float.md) | Location on a 3D image (Nx3) | direct |
+| [coordinate_systems](coordinate_systems.md) | * <br/> [CoordinateSystem](CoordinateSystem.md) | Named coordinate systems for this entity | [CoordMetaMixin](CoordMetaMixin.md) |
+| [coordinate_transformations](coordinate_transformations.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md) | Named coordinate systems for this entity | [CoordMetaMixin](CoordMetaMixin.md) |
+| [path](path.md) | 0..1 <br/> [String](String.md) | Path to a file | [Annotation](Annotation.md) |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:PointSet3D |
+| native | https://w3id.org/cetmd/entities/:PointSet3D |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: PointSet3D
+description: A set of 3D point annotations.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- CoordMetaMixin
+slots:
+- origin3D
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: PointSet3D
+description: A set of 3D point annotations.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- CoordMetaMixin
+attributes:
+  origin3D:
+    name: origin3D
+    description: Location on a 3D image (Nx3).
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    array:
+      exact_number_dimensions: 2
+      dimensions:
+      - alias: N
+        minimum_cardinality: 1
+      - alias: xyz
+        exact_cardinality: 3
+    alias: origin3D
+    owner: PointSet3D
+    domain_of:
+    - PointSet3D
+    - PointVectorSet3D
+    - PointMatrixSet3D
+    range: float
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_systems
+    owner: PointSet3D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_transformations
+    owner: PointSet3D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateTransformation
+    multivalued: true
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: path
+    owner: PointSet3D
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    range: string
+
+```
+</details>

--- a/docs/PointVectorSet2D.md
+++ b/docs/PointVectorSet2D.md
@@ -1,0 +1,226 @@
+
+
+# Class: PointVectorSet2D
+
+
+_A set of 2D points with an associated direction vector._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:PointVectorSet2D](https://w3id.org/cetmd/entities/:PointVectorSet2D)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class PointVectorSet2D
+    click PointVectorSet2D href "../PointVectorSet2D"
+      CoordMetaMixin <|-- PointVectorSet2D
+        click CoordMetaMixin href "../CoordMetaMixin"
+      Annotation <|-- PointVectorSet2D
+        click Annotation href "../Annotation"
+      
+      PointVectorSet2D : coordinate_systems
+        
+          
+    
+    
+    PointVectorSet2D --> "*" CoordinateSystem : coordinate_systems
+    click CoordinateSystem href "../CoordinateSystem"
+
+        
+      PointVectorSet2D : coordinate_transformations
+        
+          
+    
+    
+    PointVectorSet2D --> "*" CoordinateTransformation : coordinate_transformations
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      PointVectorSet2D : origin2D
+        
+      PointVectorSet2D : path
+        
+      PointVectorSet2D : vector2D
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Annotation](Annotation.md)
+    * **PointVectorSet2D** [ [CoordMetaMixin](CoordMetaMixin.md)]
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [origin2D](origin2D.md) | 0..1 <br/> [Float](Float.md) | Location on a 2D image (Nx2) | direct |
+| [vector2D](vector2D.md) | 0..1 <br/> [Float](Float.md) | Orientation vector associated with a point on a 2D image (Nx2) | direct |
+| [coordinate_systems](coordinate_systems.md) | * <br/> [CoordinateSystem](CoordinateSystem.md) | Named coordinate systems for this entity | [CoordMetaMixin](CoordMetaMixin.md) |
+| [coordinate_transformations](coordinate_transformations.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md) | Named coordinate systems for this entity | [CoordMetaMixin](CoordMetaMixin.md) |
+| [path](path.md) | 0..1 <br/> [String](String.md) | Path to a file | [Annotation](Annotation.md) |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:PointVectorSet2D |
+| native | https://w3id.org/cetmd/entities/:PointVectorSet2D |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: PointVectorSet2D
+description: A set of 2D points with an associated direction vector.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- CoordMetaMixin
+slots:
+- origin2D
+- vector2D
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: PointVectorSet2D
+description: A set of 2D points with an associated direction vector.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- CoordMetaMixin
+attributes:
+  origin2D:
+    name: origin2D
+    description: Location on a 2D image (Nx2).
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    array:
+      exact_number_dimensions: 2
+      dimensions:
+      - alias: N
+        minimum_cardinality: 1
+      - alias: xy
+        exact_cardinality: 2
+    alias: origin2D
+    owner: PointVectorSet2D
+    domain_of:
+    - PointSet2D
+    - PointVectorSet2D
+    - PointMatrixSet2D
+    range: float
+  vector2D:
+    name: vector2D
+    description: Orientation vector associated with a point on a 2D image (Nx2).
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    array:
+      exact_number_dimensions: 2
+      dimensions:
+      - alias: N
+        minimum_cardinality: 1
+      - alias: xy
+        exact_cardinality: 2
+    alias: vector2D
+    owner: PointVectorSet2D
+    domain_of:
+    - PointVectorSet2D
+    range: float
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_systems
+    owner: PointVectorSet2D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_transformations
+    owner: PointVectorSet2D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateTransformation
+    multivalued: true
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: path
+    owner: PointVectorSet2D
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    range: string
+
+```
+</details>

--- a/docs/PointVectorSet3D.md
+++ b/docs/PointVectorSet3D.md
@@ -1,0 +1,226 @@
+
+
+# Class: PointVectorSet3D
+
+
+_A set of 3D points with an associated direction vector._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:PointVectorSet3D](https://w3id.org/cetmd/entities/:PointVectorSet3D)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class PointVectorSet3D
+    click PointVectorSet3D href "../PointVectorSet3D"
+      CoordMetaMixin <|-- PointVectorSet3D
+        click CoordMetaMixin href "../CoordMetaMixin"
+      Annotation <|-- PointVectorSet3D
+        click Annotation href "../Annotation"
+      
+      PointVectorSet3D : coordinate_systems
+        
+          
+    
+    
+    PointVectorSet3D --> "*" CoordinateSystem : coordinate_systems
+    click CoordinateSystem href "../CoordinateSystem"
+
+        
+      PointVectorSet3D : coordinate_transformations
+        
+          
+    
+    
+    PointVectorSet3D --> "*" CoordinateTransformation : coordinate_transformations
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      PointVectorSet3D : origin3D
+        
+      PointVectorSet3D : path
+        
+      PointVectorSet3D : vector3D
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Annotation](Annotation.md)
+    * **PointVectorSet3D** [ [CoordMetaMixin](CoordMetaMixin.md)]
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [origin3D](origin3D.md) | 0..1 <br/> [Float](Float.md) | Location on a 3D image (Nx3) | direct |
+| [vector3D](vector3D.md) | 0..1 <br/> [Float](Float.md) | Orientation vector associated with a point on a 3D image (Nx3) | direct |
+| [coordinate_systems](coordinate_systems.md) | * <br/> [CoordinateSystem](CoordinateSystem.md) | Named coordinate systems for this entity | [CoordMetaMixin](CoordMetaMixin.md) |
+| [coordinate_transformations](coordinate_transformations.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md) | Named coordinate systems for this entity | [CoordMetaMixin](CoordMetaMixin.md) |
+| [path](path.md) | 0..1 <br/> [String](String.md) | Path to a file | [Annotation](Annotation.md) |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:PointVectorSet3D |
+| native | https://w3id.org/cetmd/entities/:PointVectorSet3D |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: PointVectorSet3D
+description: A set of 3D points with an associated direction vector.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- CoordMetaMixin
+slots:
+- origin3D
+- vector3D
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: PointVectorSet3D
+description: A set of 3D points with an associated direction vector.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- CoordMetaMixin
+attributes:
+  origin3D:
+    name: origin3D
+    description: Location on a 3D image (Nx3).
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    array:
+      exact_number_dimensions: 2
+      dimensions:
+      - alias: N
+        minimum_cardinality: 1
+      - alias: xyz
+        exact_cardinality: 3
+    alias: origin3D
+    owner: PointVectorSet3D
+    domain_of:
+    - PointSet3D
+    - PointVectorSet3D
+    - PointMatrixSet3D
+    range: float
+  vector3D:
+    name: vector3D
+    description: Orientation vector associated with a point on a 3D image (Nx3).
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    array:
+      exact_number_dimensions: 2
+      dimensions:
+      - alias: N
+        minimum_cardinality: 1
+      - alias: xyz
+        exact_cardinality: 3
+    alias: vector3D
+    owner: PointVectorSet3D
+    domain_of:
+    - PointVectorSet3D
+    range: float
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_systems
+    owner: PointVectorSet3D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_transformations
+    owner: PointVectorSet3D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateTransformation
+    multivalued: true
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: path
+    owner: PointVectorSet3D
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    range: string
+
+```
+</details>

--- a/docs/ProbabilityMap2D.md
+++ b/docs/ProbabilityMap2D.md
@@ -1,0 +1,209 @@
+
+
+# Class: ProbabilityMap2D
+
+
+_An annotation image with real-valued labels._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:ProbabilityMap2D](https://w3id.org/cetmd/entities/:ProbabilityMap2D)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class ProbabilityMap2D
+    click ProbabilityMap2D href "../ProbabilityMap2D"
+      Image2D <|-- ProbabilityMap2D
+        click Image2D href "../Image2D"
+      Annotation <|-- ProbabilityMap2D
+        click Annotation href "../Annotation"
+      
+      ProbabilityMap2D : coordinate_systems
+        
+          
+    
+    
+    ProbabilityMap2D --> "*" CoordinateSystem : coordinate_systems
+    click CoordinateSystem href "../CoordinateSystem"
+
+        
+      ProbabilityMap2D : coordinate_transformations
+        
+          
+    
+    
+    ProbabilityMap2D --> "*" CoordinateTransformation : coordinate_transformations
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      ProbabilityMap2D : height
+        
+      ProbabilityMap2D : path
+        
+      ProbabilityMap2D : width
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Annotation](Annotation.md)
+    * **ProbabilityMap2D** [ [Image2D](Image2D.md)]
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [width](width.md) | 0..1 <br/> [Integer](Integer.md) | The width of the image (x-axis) in pixels | [Image2D](Image2D.md) |
+| [height](height.md) | 0..1 <br/> [Integer](Integer.md) | The height of the image (y-axis) in pixels | [Image2D](Image2D.md) |
+| [coordinate_systems](coordinate_systems.md) | * <br/> [CoordinateSystem](CoordinateSystem.md) | Named coordinate systems for this entity | [Image2D](Image2D.md) |
+| [coordinate_transformations](coordinate_transformations.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md) | Named coordinate systems for this entity | [Image2D](Image2D.md) |
+| [path](path.md) | 0..1 <br/> [String](String.md) | Path to a file | [Annotation](Annotation.md) |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:ProbabilityMap2D |
+| native | https://w3id.org/cetmd/entities/:ProbabilityMap2D |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: ProbabilityMap2D
+description: An annotation image with real-valued labels.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- Image2D
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: ProbabilityMap2D
+description: An annotation image with real-valued labels.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- Image2D
+attributes:
+  width:
+    name: width
+    description: The width of the image (x-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: width
+    owner: ProbabilityMap2D
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  height:
+    name: height
+    description: The height of the image (y-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: height
+    owner: ProbabilityMap2D
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_systems
+    owner: ProbabilityMap2D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_transformations
+    owner: ProbabilityMap2D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateTransformation
+    multivalued: true
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: path
+    owner: ProbabilityMap2D
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    range: string
+
+```
+</details>

--- a/docs/ProbabilityMap3D.md
+++ b/docs/ProbabilityMap3D.md
@@ -1,0 +1,222 @@
+
+
+# Class: ProbabilityMap3D
+
+
+_An annotation volume with real-valued labels._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:ProbabilityMap3D](https://w3id.org/cetmd/entities/:ProbabilityMap3D)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class ProbabilityMap3D
+    click ProbabilityMap3D href "../ProbabilityMap3D"
+      Image3D <|-- ProbabilityMap3D
+        click Image3D href "../Image3D"
+      Annotation <|-- ProbabilityMap3D
+        click Annotation href "../Annotation"
+      
+      ProbabilityMap3D : coordinate_systems
+        
+          
+    
+    
+    ProbabilityMap3D --> "*" CoordinateSystem : coordinate_systems
+    click CoordinateSystem href "../CoordinateSystem"
+
+        
+      ProbabilityMap3D : coordinate_transformations
+        
+          
+    
+    
+    ProbabilityMap3D --> "*" CoordinateTransformation : coordinate_transformations
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      ProbabilityMap3D : depth
+        
+      ProbabilityMap3D : height
+        
+      ProbabilityMap3D : path
+        
+      ProbabilityMap3D : width
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Annotation](Annotation.md)
+    * **ProbabilityMap3D** [ [Image3D](Image3D.md)]
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [width](width.md) | 0..1 <br/> [Integer](Integer.md) | The width of the image (x-axis) in pixels | [Image3D](Image3D.md) |
+| [height](height.md) | 0..1 <br/> [Integer](Integer.md) | The height of the image (y-axis) in pixels | [Image3D](Image3D.md) |
+| [depth](depth.md) | 0..1 <br/> [Integer](Integer.md) | The depth of the image (z-axis) in pixels | [Image3D](Image3D.md) |
+| [coordinate_systems](coordinate_systems.md) | * <br/> [CoordinateSystem](CoordinateSystem.md) | Named coordinate systems for this entity | [Image3D](Image3D.md) |
+| [coordinate_transformations](coordinate_transformations.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md) | Named coordinate systems for this entity | [Image3D](Image3D.md) |
+| [path](path.md) | 0..1 <br/> [String](String.md) | Path to a file | [Annotation](Annotation.md) |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:ProbabilityMap3D |
+| native | https://w3id.org/cetmd/entities/:ProbabilityMap3D |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: ProbabilityMap3D
+description: An annotation volume with real-valued labels.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- Image3D
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: ProbabilityMap3D
+description: An annotation volume with real-valued labels.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- Image3D
+attributes:
+  width:
+    name: width
+    description: The width of the image (x-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: width
+    owner: ProbabilityMap3D
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  height:
+    name: height
+    description: The height of the image (y-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: height
+    owner: ProbabilityMap3D
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  depth:
+    name: depth
+    description: The depth of the image (z-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: depth
+    owner: ProbabilityMap3D
+    domain_of:
+    - Image3D
+    range: integer
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_systems
+    owner: ProbabilityMap3D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_transformations
+    owner: ProbabilityMap3D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateTransformation
+    multivalued: true
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: path
+    owner: ProbabilityMap3D
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    range: string
+
+```
+</details>

--- a/docs/ProjectionAlignment.md
+++ b/docs/ProjectionAlignment.md
@@ -1,0 +1,239 @@
+
+
+# Class: ProjectionAlignment
+
+
+_The tomographic alignment for a single projection._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:ProjectionAlignment](https://w3id.org/cetmd/entities/:ProjectionAlignment)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class ProjectionAlignment
+    click ProjectionAlignment href "../ProjectionAlignment"
+      Sequence <|-- ProjectionAlignment
+        click Sequence href "../Sequence"
+      
+      ProjectionAlignment : input
+        
+      ProjectionAlignment : name
+        
+      ProjectionAlignment : output
+        
+      ProjectionAlignment : sequence
+        
+          
+    
+    
+    ProjectionAlignment --> "*" CoordinateTransformation : sequence
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      ProjectionAlignment : transformation_type
+        
+          
+    
+    
+    ProjectionAlignment --> "0..1" TransformationType : transformation_type
+    click TransformationType href "../TransformationType"
+
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [CoordinateTransformation](CoordinateTransformation.md)
+    * [Sequence](Sequence.md)
+        * **ProjectionAlignment**
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [input](input.md) | 0..1 <br/> [String](String.md) | The source coordinate system name | direct |
+| [output](output.md) | 0..1 <br/> [String](String.md) | The target coordinate system name | direct |
+| [sequence](sequence.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md)&nbsp;or&nbsp;<br />[Affine](Affine.md)&nbsp;or&nbsp;<br />[Translation](Translation.md) | The sequence of transformations | direct |
+| [transformation_type](transformation_type.md) | 0..1 <br/> [TransformationType](TransformationType.md) | The type of transformation | [Sequence](Sequence.md), [CoordinateTransformation](CoordinateTransformation.md) |
+| [name](name.md) | 0..1 <br/> [String](String.md) | The name of the coordinate transformation | [CoordinateTransformation](CoordinateTransformation.md) |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [Alignment](Alignment.md) | [projection_alignments](projection_alignments.md) | range | [ProjectionAlignment](ProjectionAlignment.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:ProjectionAlignment |
+| native | https://w3id.org/cetmd/entities/:ProjectionAlignment |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: ProjectionAlignment
+description: The tomographic alignment for a single projection.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Sequence
+attributes:
+  input:
+    name: input
+    description: The source coordinate system name
+    from_schema: https://w3id.org/cetmd/alignment/
+    domain_of:
+    - CoordinateTransformation
+    - ProjectionAlignment
+    range: string
+  output:
+    name: output
+    description: The target coordinate system name
+    from_schema: https://w3id.org/cetmd/alignment/
+    domain_of:
+    - CoordinateTransformation
+    - ProjectionAlignment
+    range: string
+  sequence:
+    name: sequence
+    description: The sequence of transformations
+    from_schema: https://w3id.org/cetmd/alignment/
+    domain_of:
+    - Sequence
+    - ProjectionAlignment
+    range: CoordinateTransformation
+    multivalued: true
+    maximum_cardinality: 2
+    any_of:
+    - range: Affine
+    - range: Translation
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: ProjectionAlignment
+description: The tomographic alignment for a single projection.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Sequence
+attributes:
+  input:
+    name: input
+    description: The source coordinate system name
+    from_schema: https://w3id.org/cetmd/alignment/
+    alias: input
+    owner: ProjectionAlignment
+    domain_of:
+    - CoordinateTransformation
+    - ProjectionAlignment
+    range: string
+  output:
+    name: output
+    description: The target coordinate system name
+    from_schema: https://w3id.org/cetmd/alignment/
+    alias: output
+    owner: ProjectionAlignment
+    domain_of:
+    - CoordinateTransformation
+    - ProjectionAlignment
+    range: string
+  sequence:
+    name: sequence
+    description: The sequence of transformations
+    from_schema: https://w3id.org/cetmd/alignment/
+    alias: sequence
+    owner: ProjectionAlignment
+    domain_of:
+    - Sequence
+    - ProjectionAlignment
+    range: CoordinateTransformation
+    multivalued: true
+    maximum_cardinality: 2
+    any_of:
+    - range: Affine
+    - range: Translation
+  transformation_type:
+    name: transformation_type
+    description: The type of transformation
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    ifabsent: sequence
+    alias: transformation_type
+    owner: ProjectionAlignment
+    domain_of:
+    - CoordinateTransformation
+    - Identity
+    - MapAxis
+    - Translation
+    - Scale
+    - Affine
+    - Sequence
+    range: TransformationType
+  name:
+    name: name
+    description: The name of the coordinate transformation
+    from_schema: https://w3id.org/cetmd/coord_transforms
+    alias: name
+    owner: ProjectionAlignment
+    domain_of:
+    - Average
+    - Dataset
+    - CoordinateSystem
+    - CoordinateTransformation
+    range: string
+
+```
+</details>

--- a/docs/ProjectionAlignment.md
+++ b/docs/ProjectionAlignment.md
@@ -68,7 +68,7 @@ URI: [https://w3id.org/cetmd/entities/:ProjectionAlignment](https://w3id.org/cet
 | [input](input.md) | 0..1 <br/> [String](String.md) | The source coordinate system name | direct |
 | [output](output.md) | 0..1 <br/> [String](String.md) | The target coordinate system name | direct |
 | [sequence](sequence.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md)&nbsp;or&nbsp;<br />[Affine](Affine.md)&nbsp;or&nbsp;<br />[Translation](Translation.md) | The sequence of transformations | direct |
-| [transformation_type](transformation_type.md) | 0..1 <br/> [TransformationType](TransformationType.md) | The type of transformation | [Sequence](Sequence.md), [CoordinateTransformation](CoordinateTransformation.md) |
+| [transformation_type](transformation_type.md) | 0..1 <br/> [TransformationType](TransformationType.md) | The type of transformation | [CoordinateTransformation](CoordinateTransformation.md), [Sequence](Sequence.md) |
 | [name](name.md) | 0..1 <br/> [String](String.md) | The name of the coordinate transformation | [CoordinateTransformation](CoordinateTransformation.md) |
 
 

--- a/docs/ProjectionImage.md
+++ b/docs/ProjectionImage.md
@@ -1,0 +1,285 @@
+
+
+# Class: ProjectionImage
+
+
+_A projection image._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:ProjectionImage](https://w3id.org/cetmd/entities/:ProjectionImage)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class ProjectionImage
+    click ProjectionImage href "../ProjectionImage"
+      AcquisitionMetadataMixin <|-- ProjectionImage
+        click AcquisitionMetadataMixin href "../AcquisitionMetadataMixin"
+      Image2D <|-- ProjectionImage
+        click Image2D href "../Image2D"
+      
+
+      ProjectionImage <|-- SubProjectionImage
+        click SubProjectionImage href "../SubProjectionImage"
+      
+      
+      ProjectionImage : accumulated_dose
+        
+      ProjectionImage : coordinate_systems
+        
+          
+    
+    
+    ProjectionImage --> "*" CoordinateSystem : coordinate_systems
+    click CoordinateSystem href "../CoordinateSystem"
+
+        
+      ProjectionImage : coordinate_transformations
+        
+          
+    
+    
+    ProjectionImage --> "*" CoordinateTransformation : coordinate_transformations
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      ProjectionImage : ctf_metadata
+        
+          
+    
+    
+    ProjectionImage --> "0..1" CTFMetadata : ctf_metadata
+    click CTFMetadata href "../CTFMetadata"
+
+        
+      ProjectionImage : height
+        
+      ProjectionImage : nominal_tilt_angle
+        
+      ProjectionImage : path
+        
+      ProjectionImage : section
+        
+      ProjectionImage : width
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Image2D](Image2D.md)
+    * **ProjectionImage** [ [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md)]
+        * [SubProjectionImage](SubProjectionImage.md)
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [path](path.md) | 0..1 <br/> [String](String.md) | Path to a file | direct |
+| [section](section.md) | 0..1 <br/> [Integer](Integer.md) | 0-based section index to the entity inside a stack | direct |
+| [nominal_tilt_angle](nominal_tilt_angle.md) | 0..1 <br/> [Float](Float.md) | The tilt angle reported by the microscope | [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md) |
+| [accumulated_dose](accumulated_dose.md) | 0..1 <br/> [Float](Float.md) | The pre-exposure up to this image in e-/A^2 | [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md) |
+| [ctf_metadata](ctf_metadata.md) | 0..1 <br/> [CTFMetadata](CTFMetadata.md) | A set of CTF patameters for an image | [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md) |
+| [width](width.md) | 0..1 <br/> [Integer](Integer.md) | The width of the image (x-axis) in pixels | [Image2D](Image2D.md) |
+| [height](height.md) | 0..1 <br/> [Integer](Integer.md) | The height of the image (y-axis) in pixels | [Image2D](Image2D.md) |
+| [coordinate_systems](coordinate_systems.md) | * <br/> [CoordinateSystem](CoordinateSystem.md) | Named coordinate systems for this entity | [Image2D](Image2D.md) |
+| [coordinate_transformations](coordinate_transformations.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md) | Named coordinate systems for this entity | [Image2D](Image2D.md) |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [TiltSeries](TiltSeries.md) | [images_tilt](images_tilt.md) | range | [ProjectionImage](ProjectionImage.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:ProjectionImage |
+| native | https://w3id.org/cetmd/entities/:ProjectionImage |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: ProjectionImage
+description: A projection image.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Image2D
+mixins:
+- AcquisitionMetadataMixin
+slots:
+- path
+- section
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: ProjectionImage
+description: A projection image.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Image2D
+mixins:
+- AcquisitionMetadataMixin
+attributes:
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: path
+    owner: ProjectionImage
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    range: string
+  section:
+    name: section
+    description: 0-based section index to the entity inside a stack.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: section
+    owner: ProjectionImage
+    domain_of:
+    - MovieFrame
+    - ProjectionImage
+    range: integer
+  nominal_tilt_angle:
+    name: nominal_tilt_angle
+    description: The tilt angle reported by the microscope
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: nominal_tilt_angle
+    owner: ProjectionImage
+    domain_of:
+    - AcquisitionMetadataMixin
+    range: float
+  accumulated_dose:
+    name: accumulated_dose
+    description: The pre-exposure up to this image in e-/A^2
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: accumulated_dose
+    owner: ProjectionImage
+    domain_of:
+    - AcquisitionMetadataMixin
+    range: float
+  ctf_metadata:
+    name: ctf_metadata
+    description: A set of CTF patameters for an image.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: ctf_metadata
+    owner: ProjectionImage
+    domain_of:
+    - AcquisitionMetadataMixin
+    range: CTFMetadata
+  width:
+    name: width
+    description: The width of the image (x-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: width
+    owner: ProjectionImage
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  height:
+    name: height
+    description: The height of the image (y-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: height
+    owner: ProjectionImage
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_systems
+    owner: ProjectionImage
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_transformations
+    owner: ProjectionImage
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateTransformation
+    multivalued: true
+
+```
+</details>

--- a/docs/Region.md
+++ b/docs/Region.md
@@ -1,0 +1,253 @@
+
+
+# Class: Region
+
+
+_Raw data (movie stacks) and derived data (tilt series, tomograms, annotations) from a single region of a specimen._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:Region](https://w3id.org/cetmd/entities/:Region)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class Region
+    click Region href "../Region"
+      Region : alignments
+        
+          
+    
+    
+    Region --> "*" Alignment : alignments
+    click Alignment href "../Alignment"
+
+        
+      Region : annotations
+        
+          
+    
+    
+    Region --> "*" Annotation : annotations
+    click Annotation href "../Annotation"
+
+        
+      Region : movie_stack_collections
+        
+          
+    
+    
+    Region --> "*" MovieStackCollection : movie_stack_collections
+    click MovieStackCollection href "../MovieStackCollection"
+
+        
+      Region : tilt_series
+        
+          
+    
+    
+    Region --> "*" TiltSeries : tilt_series
+    click TiltSeries href "../TiltSeries"
+
+        
+      Region : tomograms
+        
+          
+    
+    
+    Region --> "*" Tomogram : tomograms
+    click Tomogram href "../Tomogram"
+
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [annotations](annotations.md) | * <br/> [Annotation](Annotation.md) | The annotations | direct |
+| [movie_stack_collections](movie_stack_collections.md) | * <br/> [MovieStackCollection](MovieStackCollection.md) | The movie stack | direct |
+| [tilt_series](tilt_series.md) | * <br/> [TiltSeries](TiltSeries.md) | The tilt series | direct |
+| [alignments](alignments.md) | * <br/> [Alignment](Alignment.md) | The alignments | direct |
+| [tomograms](tomograms.md) | * <br/> [Tomogram](Tomogram.md) | The tomograms | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [Dataset](Dataset.md) | [regions](regions.md) | range | [Region](Region.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:Region |
+| native | https://w3id.org/cetmd/entities/:Region |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: Region
+description: Raw data (movie stacks) and derived data (tilt series, tomograms, annotations)
+  from a single region of a specimen.
+from_schema: https://w3id.org/cetmd/entities
+slots:
+- annotations
+attributes:
+  movie_stack_collections:
+    name: movie_stack_collections
+    description: The movie stack
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    domain_of:
+    - Region
+    range: MovieStackCollection
+    multivalued: true
+  tilt_series:
+    name: tilt_series
+    description: The tilt series
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    domain_of:
+    - Region
+    range: TiltSeries
+    multivalued: true
+  alignments:
+    name: alignments
+    description: The alignments
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    domain_of:
+    - Region
+    range: Alignment
+    multivalued: true
+  tomograms:
+    name: tomograms
+    description: The tomograms
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    domain_of:
+    - Region
+    range: Tomogram
+    multivalued: true
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: Region
+description: Raw data (movie stacks) and derived data (tilt series, tomograms, annotations)
+  from a single region of a specimen.
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  movie_stack_collections:
+    name: movie_stack_collections
+    description: The movie stack
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: movie_stack_collections
+    owner: Region
+    domain_of:
+    - Region
+    range: MovieStackCollection
+    multivalued: true
+  tilt_series:
+    name: tilt_series
+    description: The tilt series
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: tilt_series
+    owner: Region
+    domain_of:
+    - Region
+    range: TiltSeries
+    multivalued: true
+  alignments:
+    name: alignments
+    description: The alignments
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: alignments
+    owner: Region
+    domain_of:
+    - Region
+    range: Alignment
+    multivalued: true
+  tomograms:
+    name: tomograms
+    description: The tomograms
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: tomograms
+    owner: Region
+    domain_of:
+    - Region
+    range: Tomogram
+    multivalued: true
+  annotations:
+    name: annotations
+    description: The annotations
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: annotations
+    owner: Region
+    domain_of:
+    - Region
+    - Average
+    range: Annotation
+    multivalued: true
+
+```
+</details>

--- a/docs/Scale.md
+++ b/docs/Scale.md
@@ -1,0 +1,86 @@
+
+
+# Slot: scale
+
+
+_The scaling vector_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:scale](https://w3id.org/cetmd/entities/:scale)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Scale](Scale.md) | A scaling transformation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Float](Float.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:scale |
+| native | https://w3id.org/cetmd/entities/:scale |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: scale
+description: The scaling vector
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: scale
+owner: Scale
+domain_of:
+- Scale
+range: float
+multivalued: true
+
+```
+</details>

--- a/docs/SegmentationMask2D.md
+++ b/docs/SegmentationMask2D.md
@@ -1,0 +1,209 @@
+
+
+# Class: SegmentationMask2D
+
+
+_An annotation image with categorical labels._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:SegmentationMask2D](https://w3id.org/cetmd/entities/:SegmentationMask2D)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class SegmentationMask2D
+    click SegmentationMask2D href "../SegmentationMask2D"
+      Image2D <|-- SegmentationMask2D
+        click Image2D href "../Image2D"
+      Annotation <|-- SegmentationMask2D
+        click Annotation href "../Annotation"
+      
+      SegmentationMask2D : coordinate_systems
+        
+          
+    
+    
+    SegmentationMask2D --> "*" CoordinateSystem : coordinate_systems
+    click CoordinateSystem href "../CoordinateSystem"
+
+        
+      SegmentationMask2D : coordinate_transformations
+        
+          
+    
+    
+    SegmentationMask2D --> "*" CoordinateTransformation : coordinate_transformations
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      SegmentationMask2D : height
+        
+      SegmentationMask2D : path
+        
+      SegmentationMask2D : width
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Annotation](Annotation.md)
+    * **SegmentationMask2D** [ [Image2D](Image2D.md)]
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [width](width.md) | 0..1 <br/> [Integer](Integer.md) | The width of the image (x-axis) in pixels | [Image2D](Image2D.md) |
+| [height](height.md) | 0..1 <br/> [Integer](Integer.md) | The height of the image (y-axis) in pixels | [Image2D](Image2D.md) |
+| [coordinate_systems](coordinate_systems.md) | * <br/> [CoordinateSystem](CoordinateSystem.md) | Named coordinate systems for this entity | [Image2D](Image2D.md) |
+| [coordinate_transformations](coordinate_transformations.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md) | Named coordinate systems for this entity | [Image2D](Image2D.md) |
+| [path](path.md) | 0..1 <br/> [String](String.md) | Path to a file | [Annotation](Annotation.md) |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:SegmentationMask2D |
+| native | https://w3id.org/cetmd/entities/:SegmentationMask2D |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: SegmentationMask2D
+description: An annotation image with categorical labels.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- Image2D
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: SegmentationMask2D
+description: An annotation image with categorical labels.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- Image2D
+attributes:
+  width:
+    name: width
+    description: The width of the image (x-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: width
+    owner: SegmentationMask2D
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  height:
+    name: height
+    description: The height of the image (y-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: height
+    owner: SegmentationMask2D
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_systems
+    owner: SegmentationMask2D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_transformations
+    owner: SegmentationMask2D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateTransformation
+    multivalued: true
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: path
+    owner: SegmentationMask2D
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    range: string
+
+```
+</details>

--- a/docs/SegmentationMask3D.md
+++ b/docs/SegmentationMask3D.md
@@ -1,0 +1,222 @@
+
+
+# Class: SegmentationMask3D
+
+
+_An annotation volume with categorical labels._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:SegmentationMask3D](https://w3id.org/cetmd/entities/:SegmentationMask3D)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class SegmentationMask3D
+    click SegmentationMask3D href "../SegmentationMask3D"
+      Image3D <|-- SegmentationMask3D
+        click Image3D href "../Image3D"
+      Annotation <|-- SegmentationMask3D
+        click Annotation href "../Annotation"
+      
+      SegmentationMask3D : coordinate_systems
+        
+          
+    
+    
+    SegmentationMask3D --> "*" CoordinateSystem : coordinate_systems
+    click CoordinateSystem href "../CoordinateSystem"
+
+        
+      SegmentationMask3D : coordinate_transformations
+        
+          
+    
+    
+    SegmentationMask3D --> "*" CoordinateTransformation : coordinate_transformations
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      SegmentationMask3D : depth
+        
+      SegmentationMask3D : height
+        
+      SegmentationMask3D : path
+        
+      SegmentationMask3D : width
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Annotation](Annotation.md)
+    * **SegmentationMask3D** [ [Image3D](Image3D.md)]
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [width](width.md) | 0..1 <br/> [Integer](Integer.md) | The width of the image (x-axis) in pixels | [Image3D](Image3D.md) |
+| [height](height.md) | 0..1 <br/> [Integer](Integer.md) | The height of the image (y-axis) in pixels | [Image3D](Image3D.md) |
+| [depth](depth.md) | 0..1 <br/> [Integer](Integer.md) | The depth of the image (z-axis) in pixels | [Image3D](Image3D.md) |
+| [coordinate_systems](coordinate_systems.md) | * <br/> [CoordinateSystem](CoordinateSystem.md) | Named coordinate systems for this entity | [Image3D](Image3D.md) |
+| [coordinate_transformations](coordinate_transformations.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md) | Named coordinate systems for this entity | [Image3D](Image3D.md) |
+| [path](path.md) | 0..1 <br/> [String](String.md) | Path to a file | [Annotation](Annotation.md) |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:SegmentationMask3D |
+| native | https://w3id.org/cetmd/entities/:SegmentationMask3D |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: SegmentationMask3D
+description: An annotation volume with categorical labels.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- Image3D
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: SegmentationMask3D
+description: An annotation volume with categorical labels.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- Image3D
+attributes:
+  width:
+    name: width
+    description: The width of the image (x-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: width
+    owner: SegmentationMask3D
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  height:
+    name: height
+    description: The height of the image (y-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: height
+    owner: SegmentationMask3D
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  depth:
+    name: depth
+    description: The depth of the image (z-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: depth
+    owner: SegmentationMask3D
+    domain_of:
+    - Image3D
+    range: integer
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_systems
+    owner: SegmentationMask3D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_transformations
+    owner: SegmentationMask3D
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateTransformation
+    multivalued: true
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: path
+    owner: SegmentationMask3D
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    range: string
+
+```
+</details>

--- a/docs/Sequence.md
+++ b/docs/Sequence.md
@@ -1,0 +1,68 @@
+
+
+# Slot: sequence
+
+
+
+URI: [https://w3id.org/cetmd/entities/:sequence](https://w3id.org/cetmd/entities/:sequence)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Sequence](Sequence.md) | A sequence of transformations |  no  |
+| [ProjectionAlignment](ProjectionAlignment.md) | The tomographic alignment for a single projection |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: NONE
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:sequence |
+| native | https://w3id.org/cetmd/entities/:sequence |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: sequence
+alias: sequence
+domain_of:
+- Sequence
+- ProjectionAlignment
+
+```
+</details>

--- a/docs/Sequence.md
+++ b/docs/Sequence.md
@@ -18,8 +18,8 @@ URI: [https://w3id.org/cetmd/entities/:sequence](https://w3id.org/cetmd/entities
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [Sequence](Sequence.md) | A sequence of transformations |  no  |
 | [ProjectionAlignment](ProjectionAlignment.md) | The tomographic alignment for a single projection |  no  |
+| [Sequence](Sequence.md) | A sequence of transformations |  no  |
 
 
 

--- a/docs/Sparqlpath.md
+++ b/docs/Sparqlpath.md
@@ -1,0 +1,49 @@
+# Type: Sparqlpath
+
+
+
+
+_A string encoding a SPARQL Property Path. The value of the string MUST conform to SPARQL syntax and SHOULD dereference to zero or more valid objects within the current instance document when encoded as RDF._
+
+
+
+URI: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+* [base](https://w3id.org/linkml/base): str
+
+* [uri](https://w3id.org/linkml/uri): xsd:string
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:string |
+| native | https://w3id.org/cetmd/entities/:sparqlpath |
+
+
+

--- a/docs/String.md
+++ b/docs/String.md
@@ -1,0 +1,49 @@
+# Type: String
+
+
+
+
+_A character string_
+
+
+
+URI: [xsd:string](http://www.w3.org/2001/XMLSchema#string)
+
+* [base](https://w3id.org/linkml/base): str
+
+* [uri](https://w3id.org/linkml/uri): xsd:string
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:string |
+| native | https://w3id.org/cetmd/entities/:string |
+| exact | schema:Text |
+
+
+

--- a/docs/SubProjectionImage.md
+++ b/docs/SubProjectionImage.md
@@ -1,0 +1,279 @@
+
+
+# Class: SubProjectionImage
+
+
+_A croppecd projection image._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:SubProjectionImage](https://w3id.org/cetmd/entities/:SubProjectionImage)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class SubProjectionImage
+    click SubProjectionImage href "../SubProjectionImage"
+      ProjectionImage <|-- SubProjectionImage
+        click ProjectionImage href "../ProjectionImage"
+      
+      SubProjectionImage : accumulated_dose
+        
+      SubProjectionImage : coordinate_systems
+        
+          
+    
+    
+    SubProjectionImage --> "*" CoordinateSystem : coordinate_systems
+    click CoordinateSystem href "../CoordinateSystem"
+
+        
+      SubProjectionImage : coordinate_transformations
+        
+          
+    
+    
+    SubProjectionImage --> "*" CoordinateTransformation : coordinate_transformations
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      SubProjectionImage : ctf_metadata
+        
+          
+    
+    
+    SubProjectionImage --> "0..1" CTFMetadata : ctf_metadata
+    click CTFMetadata href "../CTFMetadata"
+
+        
+      SubProjectionImage : height
+        
+      SubProjectionImage : nominal_tilt_angle
+        
+      SubProjectionImage : particle_index
+        
+      SubProjectionImage : path
+        
+      SubProjectionImage : section
+        
+      SubProjectionImage : width
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Image2D](Image2D.md)
+    * [ProjectionImage](ProjectionImage.md) [ [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md)]
+        * **SubProjectionImage**
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [particle_index](particle_index.md) | 0..1 <br/> [Integer](Integer.md) | Index of a particle inside a tomogram | direct |
+| [path](path.md) | 0..1 <br/> [String](String.md) | Path to a file | [ProjectionImage](ProjectionImage.md) |
+| [section](section.md) | 0..1 <br/> [Integer](Integer.md) | 0-based section index to the entity inside a stack | [ProjectionImage](ProjectionImage.md) |
+| [nominal_tilt_angle](nominal_tilt_angle.md) | 0..1 <br/> [Float](Float.md) | The tilt angle reported by the microscope | [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md) |
+| [accumulated_dose](accumulated_dose.md) | 0..1 <br/> [Float](Float.md) | The pre-exposure up to this image in e-/A^2 | [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md) |
+| [ctf_metadata](ctf_metadata.md) | 0..1 <br/> [CTFMetadata](CTFMetadata.md) | A set of CTF patameters for an image | [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md) |
+| [width](width.md) | 0..1 <br/> [Integer](Integer.md) | The width of the image (x-axis) in pixels | [Image2D](Image2D.md) |
+| [height](height.md) | 0..1 <br/> [Integer](Integer.md) | The height of the image (y-axis) in pixels | [Image2D](Image2D.md) |
+| [coordinate_systems](coordinate_systems.md) | * <br/> [CoordinateSystem](CoordinateSystem.md) | Named coordinate systems for this entity | [Image2D](Image2D.md) |
+| [coordinate_transformations](coordinate_transformations.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md) | Named coordinate systems for this entity | [Image2D](Image2D.md) |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:SubProjectionImage |
+| native | https://w3id.org/cetmd/entities/:SubProjectionImage |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: SubProjectionImage
+description: A croppecd projection image.
+from_schema: https://w3id.org/cetmd/entities
+is_a: ProjectionImage
+slots:
+- particle_index
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: SubProjectionImage
+description: A croppecd projection image.
+from_schema: https://w3id.org/cetmd/entities
+is_a: ProjectionImage
+attributes:
+  particle_index:
+    name: particle_index
+    description: Index of a particle inside a tomogram.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: particle_index
+    owner: SubProjectionImage
+    domain_of:
+    - SubProjectionImage
+    range: integer
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: path
+    owner: SubProjectionImage
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    range: string
+  section:
+    name: section
+    description: 0-based section index to the entity inside a stack.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: section
+    owner: SubProjectionImage
+    domain_of:
+    - MovieFrame
+    - ProjectionImage
+    range: integer
+  nominal_tilt_angle:
+    name: nominal_tilt_angle
+    description: The tilt angle reported by the microscope
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: nominal_tilt_angle
+    owner: SubProjectionImage
+    domain_of:
+    - AcquisitionMetadataMixin
+    range: float
+  accumulated_dose:
+    name: accumulated_dose
+    description: The pre-exposure up to this image in e-/A^2
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: accumulated_dose
+    owner: SubProjectionImage
+    domain_of:
+    - AcquisitionMetadataMixin
+    range: float
+  ctf_metadata:
+    name: ctf_metadata
+    description: A set of CTF patameters for an image.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: ctf_metadata
+    owner: SubProjectionImage
+    domain_of:
+    - AcquisitionMetadataMixin
+    range: CTFMetadata
+  width:
+    name: width
+    description: The width of the image (x-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: width
+    owner: SubProjectionImage
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  height:
+    name: height
+    description: The height of the image (y-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: height
+    owner: SubProjectionImage
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_systems
+    owner: SubProjectionImage
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_transformations
+    owner: SubProjectionImage
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateTransformation
+    multivalued: true
+
+```
+</details>

--- a/docs/TiltSeries.md
+++ b/docs/TiltSeries.md
@@ -1,0 +1,151 @@
+
+
+# Class: TiltSeries
+
+
+_A stack of projection images._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:TiltSeries](https://w3id.org/cetmd/entities/:TiltSeries)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class TiltSeries
+    click TiltSeries href "../TiltSeries"
+      TiltSeries : images_tilt
+        
+          
+    
+    
+    TiltSeries --> "*" ProjectionImage : images_tilt
+    click ProjectionImage href "../ProjectionImage"
+
+        
+      TiltSeries : path
+        
+      
+```
+
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [images_tilt](images_tilt.md) | * <br/> [ProjectionImage](ProjectionImage.md) | The projections in the stack | direct |
+| [path](path.md) | 0..1 <br/> [String](String.md) | Path to a file | direct |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [Region](Region.md) | [tilt_series](tilt_series.md) | range | [TiltSeries](TiltSeries.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:TiltSeries |
+| native | https://w3id.org/cetmd/entities/:TiltSeries |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: TiltSeries
+description: A stack of projection images.
+from_schema: https://w3id.org/cetmd/entities
+slots:
+- images_tilt
+- path
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: TiltSeries
+description: A stack of projection images.
+from_schema: https://w3id.org/cetmd/entities
+attributes:
+  images_tilt:
+    name: images_tilt
+    description: The projections in the stack
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: images_tilt
+    owner: TiltSeries
+    domain_of:
+    - TiltSeries
+    range: ProjectionImage
+    multivalued: true
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: path
+    owner: TiltSeries
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    range: string
+
+```
+</details>

--- a/docs/Time.md
+++ b/docs/Time.md
@@ -1,0 +1,50 @@
+# Type: Time
+
+
+
+
+_A time object represents a (local) time of day, independent of any particular day_
+
+
+
+URI: [xsd:time](http://www.w3.org/2001/XMLSchema#time)
+
+* [base](https://w3id.org/linkml/base): XSDTime
+
+* [uri](https://w3id.org/linkml/uri): xsd:time
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:time |
+| native | https://w3id.org/cetmd/entities/:time |
+| exact | schema:Time |
+
+
+

--- a/docs/Tomogram.md
+++ b/docs/Tomogram.md
@@ -1,0 +1,225 @@
+
+
+# Class: Tomogram
+
+
+_A 3D tomogram._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:Tomogram](https://w3id.org/cetmd/entities/:Tomogram)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class Tomogram
+    click Tomogram href "../Tomogram"
+      Image3D <|-- Tomogram
+        click Image3D href "../Image3D"
+      
+      Tomogram : coordinate_systems
+        
+          
+    
+    
+    Tomogram --> "*" CoordinateSystem : coordinate_systems
+    click CoordinateSystem href "../CoordinateSystem"
+
+        
+      Tomogram : coordinate_transformations
+        
+          
+    
+    
+    Tomogram --> "*" CoordinateTransformation : coordinate_transformations
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      Tomogram : depth
+        
+      Tomogram : height
+        
+      Tomogram : path
+        
+      Tomogram : width
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Image3D](Image3D.md)
+    * **Tomogram**
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [path](path.md) | 0..1 <br/> [String](String.md) | Path to a file | direct |
+| [width](width.md) | 0..1 <br/> [Integer](Integer.md) | The width of the image (x-axis) in pixels | [Image3D](Image3D.md) |
+| [height](height.md) | 0..1 <br/> [Integer](Integer.md) | The height of the image (y-axis) in pixels | [Image3D](Image3D.md) |
+| [depth](depth.md) | 0..1 <br/> [Integer](Integer.md) | The depth of the image (z-axis) in pixels | [Image3D](Image3D.md) |
+| [coordinate_systems](coordinate_systems.md) | * <br/> [CoordinateSystem](CoordinateSystem.md) | Named coordinate systems for this entity | [Image3D](Image3D.md) |
+| [coordinate_transformations](coordinate_transformations.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md) | Named coordinate systems for this entity | [Image3D](Image3D.md) |
+
+
+
+
+
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+| [Region](Region.md) | [tomograms](tomograms.md) | range | [Tomogram](Tomogram.md) |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:Tomogram |
+| native | https://w3id.org/cetmd/entities/:Tomogram |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: Tomogram
+description: A 3D tomogram.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Image3D
+slots:
+- path
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: Tomogram
+description: A 3D tomogram.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Image3D
+attributes:
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: path
+    owner: Tomogram
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    range: string
+  width:
+    name: width
+    description: The width of the image (x-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: width
+    owner: Tomogram
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  height:
+    name: height
+    description: The height of the image (y-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: height
+    owner: Tomogram
+    domain_of:
+    - Image2D
+    - Image3D
+    range: integer
+  depth:
+    name: depth
+    description: The depth of the image (z-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: depth
+    owner: Tomogram
+    domain_of:
+    - Image3D
+    range: integer
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_systems
+    owner: Tomogram
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_transformations
+    owner: Tomogram
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateTransformation
+    multivalued: true
+
+```
+</details>

--- a/docs/TransformationType.md
+++ b/docs/TransformationType.md
@@ -1,0 +1,78 @@
+# Enum: TransformationType
+
+
+
+URI: [TransformationType](TransformationType.md)
+
+## Permissible Values
+
+| Value | Meaning | Description |
+| --- | --- | --- |
+| identity | None | The identity transformation |
+| map_axis | None | Axis permutation transformation |
+| translation | None | A translation transformation |
+| scale | None | A scaling transformation |
+| affine | None | An affine transformation |
+| sequence | None | A sequence of transformations |
+
+
+
+
+## Slots
+
+| Name | Description |
+| ---  | --- |
+| [transformation_type](transformation_type.md) | The type of transformation |
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: TransformationType
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+permissible_values:
+  identity:
+    text: identity
+    description: The identity transformation.
+  map_axis:
+    text: map_axis
+    description: Axis permutation transformation
+  translation:
+    text: translation
+    description: A translation transformation.
+  scale:
+    text: scale
+    description: A scaling transformation.
+  affine:
+    text: affine
+    description: An affine transformation
+  sequence:
+    text: sequence
+    description: A sequence of transformations
+
+```
+</details>

--- a/docs/Translation.md
+++ b/docs/Translation.md
@@ -1,0 +1,86 @@
+
+
+# Slot: translation
+
+
+_The translation vector_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:translation](https://w3id.org/cetmd/entities/:translation)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Translation](Translation.md) | A translation transformation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Float](Float.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:translation |
+| native | https://w3id.org/cetmd/entities/:translation |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: translation
+description: The translation vector
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: translation
+owner: Translation
+domain_of:
+- Translation
+range: float
+multivalued: true
+
+```
+</details>

--- a/docs/TriMesh.md
+++ b/docs/TriMesh.md
@@ -1,0 +1,181 @@
+
+
+# Class: TriMesh
+
+
+_A mesh annotation._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:TriMesh](https://w3id.org/cetmd/entities/:TriMesh)
+
+
+
+
+
+
+```mermaid
+ classDiagram
+    class TriMesh
+    click TriMesh href "../TriMesh"
+      CoordMetaMixin <|-- TriMesh
+        click CoordMetaMixin href "../CoordMetaMixin"
+      Annotation <|-- TriMesh
+        click Annotation href "../Annotation"
+      
+      TriMesh : coordinate_systems
+        
+          
+    
+    
+    TriMesh --> "*" CoordinateSystem : coordinate_systems
+    click CoordinateSystem href "../CoordinateSystem"
+
+        
+      TriMesh : coordinate_transformations
+        
+          
+    
+    
+    TriMesh --> "*" CoordinateTransformation : coordinate_transformations
+    click CoordinateTransformation href "../CoordinateTransformation"
+
+        
+      TriMesh : path
+        
+      
+```
+
+
+
+
+
+## Inheritance
+* [Annotation](Annotation.md)
+    * **TriMesh** [ [CoordMetaMixin](CoordMetaMixin.md)]
+
+
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+| [coordinate_systems](coordinate_systems.md) | * <br/> [CoordinateSystem](CoordinateSystem.md) | Named coordinate systems for this entity | [CoordMetaMixin](CoordMetaMixin.md) |
+| [coordinate_transformations](coordinate_transformations.md) | * <br/> [CoordinateTransformation](CoordinateTransformation.md) | Named coordinate systems for this entity | [CoordMetaMixin](CoordMetaMixin.md) |
+| [path](path.md) | 0..1 <br/> [String](String.md) | Path to a file | [Annotation](Annotation.md) |
+
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:TriMesh |
+| native | https://w3id.org/cetmd/entities/:TriMesh |
+
+
+
+
+
+
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+name: TriMesh
+description: A mesh annotation.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- CoordMetaMixin
+
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+name: TriMesh
+description: A mesh annotation.
+from_schema: https://w3id.org/cetmd/entities
+is_a: Annotation
+mixins:
+- CoordMetaMixin
+attributes:
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_systems
+    owner: TriMesh
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: coordinate_transformations
+    owner: TriMesh
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    range: CoordinateTransformation
+    multivalued: true
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    rank: 1000
+    alias: path
+    owner: TriMesh
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    range: string
+
+```
+</details>

--- a/docs/Uri.md
+++ b/docs/Uri.md
@@ -1,0 +1,54 @@
+# Type: Uri
+
+
+
+
+_a complete URI_
+
+
+
+URI: [xsd:anyURI](http://www.w3.org/2001/XMLSchema#anyURI)
+
+* [base](https://w3id.org/linkml/base): URI
+
+* [uri](https://w3id.org/linkml/uri): xsd:anyURI
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Comments
+
+* in RDF serializations a slot with range of uri is treated as a literal or type xsd:anyURI unless it is an identifier or a reference to an identifier, in which case it is translated directly to a node
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:anyURI |
+| native | https://w3id.org/cetmd/entities/:uri |
+| close | schema:URL |
+
+
+

--- a/docs/Uriorcurie.md
+++ b/docs/Uriorcurie.md
@@ -1,0 +1,49 @@
+# Type: Uriorcurie
+
+
+
+
+_a URI or a CURIE_
+
+
+
+URI: [xsd:anyURI](http://www.w3.org/2001/XMLSchema#anyURI)
+
+* [base](https://w3id.org/linkml/base): URIorCURIE
+
+* [uri](https://w3id.org/linkml/uri): xsd:anyURI
+
+* [repr](https://w3id.org/linkml/repr): str
+
+
+
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | xsd:anyURI |
+| native | https://w3id.org/cetmd/entities/:uriorcurie |
+
+
+

--- a/docs/accumulated_dose.md
+++ b/docs/accumulated_dose.md
@@ -1,0 +1,85 @@
+
+
+# Slot: accumulated_dose
+
+
+_The pre-exposure up to this image in e-/A^2_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:accumulated_dose](https://w3id.org/cetmd/entities/:accumulated_dose)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
+| [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
+| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
+| [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md) | Metadata concerning the acquisition process |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Float](Float.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:accumulated_dose |
+| native | https://w3id.org/cetmd/entities/:accumulated_dose |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: accumulated_dose
+description: The pre-exposure up to this image in e-/A^2
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: accumulated_dose
+domain_of:
+- AcquisitionMetadataMixin
+range: float
+
+```
+</details>

--- a/docs/accumulated_dose.md
+++ b/docs/accumulated_dose.md
@@ -24,9 +24,9 @@ URI: [https://w3id.org/cetmd/entities/:accumulated_dose](https://w3id.org/cetmd/
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
 | [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
-| [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
-| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
 | [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md) | Metadata concerning the acquisition process |  no  |
+| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
+| [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
 
 
 

--- a/docs/alignments.md
+++ b/docs/alignments.md
@@ -1,0 +1,86 @@
+
+
+# Slot: alignments
+
+
+_The alignments_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:alignments](https://w3id.org/cetmd/entities/:alignments)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Region](Region.md) | Raw data (movie stacks) and derived data (tilt series, tomograms, annotations... |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Alignment](Alignment.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:alignments |
+| native | https://w3id.org/cetmd/entities/:alignments |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: alignments
+description: The alignments
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: alignments
+owner: Region
+domain_of:
+- Region
+range: Alignment
+multivalued: true
+
+```
+</details>

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -1,0 +1,87 @@
+
+
+# Slot: annotations
+
+
+_The annotations_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:annotations](https://w3id.org/cetmd/entities/:annotations)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Region](Region.md) | Raw data (movie stacks) and derived data (tilt series, tomograms, annotations... |  no  |
+| [Average](Average.md) | A particle averaging experiment |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Annotation](Annotation.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:annotations |
+| native | https://w3id.org/cetmd/entities/:annotations |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: annotations
+description: The annotations
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: annotations
+domain_of:
+- Region
+- Average
+range: Annotation
+multivalued: true
+
+```
+</details>

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -23,8 +23,8 @@ URI: [https://w3id.org/cetmd/entities/:annotations](https://w3id.org/cetmd/entit
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [Region](Region.md) | Raw data (movie stacks) and derived data (tilt series, tomograms, annotations... |  no  |
 | [Average](Average.md) | A particle averaging experiment |  no  |
+| [Region](Region.md) | Raw data (movie stacks) and derived data (tilt series, tomograms, annotations... |  no  |
 
 
 

--- a/docs/averages.md
+++ b/docs/averages.md
@@ -1,0 +1,86 @@
+
+
+# Slot: averages
+
+
+_The averages in the dataset_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:averages](https://w3id.org/cetmd/entities/:averages)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Dataset](Dataset.md) | A dataset |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Average](Average.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:averages |
+| native | https://w3id.org/cetmd/entities/:averages |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: averages
+description: The averages in the dataset
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: averages
+owner: Dataset
+domain_of:
+- Dataset
+range: Average
+multivalued: true
+
+```
+</details>

--- a/docs/axes.md
+++ b/docs/axes.md
@@ -1,0 +1,89 @@
+
+
+# Slot: axes
+
+
+_The axes of the coordinate system_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:axes](https://w3id.org/cetmd/entities/:axes)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [CoordinateSystem](CoordinateSystem.md) | A coordinate system |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Axis](Axis.md)
+
+* Multivalued: True
+
+* Required: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:axes |
+| native | https://w3id.org/cetmd/entities/:axes |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: axes
+description: The axes of the coordinate system
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: axes
+owner: CoordinateSystem
+domain_of:
+- CoordinateSystem
+range: Axis
+required: true
+multivalued: true
+
+```
+</details>

--- a/docs/axis1_name.md
+++ b/docs/axis1_name.md
@@ -1,0 +1,83 @@
+
+
+# Slot: axis1_name
+
+
+_The type of transformation_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:axis1_name](https://w3id.org/cetmd/entities/:axis1_name)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [AxisNameMapping](AxisNameMapping.md) | Axis name to Axis name mapping |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [String](String.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:axis1_name |
+| native | https://w3id.org/cetmd/entities/:axis1_name |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: axis1_name
+description: The type of transformation
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: axis1_name
+owner: AxisNameMapping
+domain_of:
+- AxisNameMapping
+range: string
+
+```
+</details>

--- a/docs/axis2_name.md
+++ b/docs/axis2_name.md
@@ -1,0 +1,83 @@
+
+
+# Slot: axis2_name
+
+
+_The mapping of the axis names_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:axis2_name](https://w3id.org/cetmd/entities/:axis2_name)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [AxisNameMapping](AxisNameMapping.md) | Axis name to Axis name mapping |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [String](String.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:axis2_name |
+| native | https://w3id.org/cetmd/entities/:axis2_name |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: axis2_name
+description: The mapping of the axis names
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: axis2_name
+owner: AxisNameMapping
+domain_of:
+- AxisNameMapping
+range: string
+
+```
+</details>

--- a/docs/axis_name.md
+++ b/docs/axis_name.md
@@ -1,0 +1,82 @@
+
+
+# Slot: axis_name
+
+
+_The name of the axis_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:axis_name](https://w3id.org/cetmd/entities/:axis_name)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Axis](Axis.md) | An axis in a coordinate system |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [String](String.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:axis_name |
+| native | https://w3id.org/cetmd/entities/:axis_name |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: axis_name
+description: The name of the axis
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: axis_name
+domain_of:
+- Axis
+range: string
+
+```
+</details>

--- a/docs/axis_name.md
+++ b/docs/axis_name.md
@@ -23,7 +23,7 @@ URI: [https://w3id.org/cetmd/entities/:axis_name](https://w3id.org/cetmd/entitie
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [Axis](Axis.md) | An axis in a coordinate system |  no  |
+| [Axis](Axis.md) | An axis in a coordinate system |  yes  |
 
 
 

--- a/docs/axis_type.md
+++ b/docs/axis_type.md
@@ -1,0 +1,82 @@
+
+
+# Slot: axis_type
+
+
+_The type of axis_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:axis_type](https://w3id.org/cetmd/entities/:axis_type)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Axis](Axis.md) | An axis in a coordinate system |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [AxisType](AxisType.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:axis_type |
+| native | https://w3id.org/cetmd/entities/:axis_type |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: axis_type
+description: The type of axis
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: axis_type
+domain_of:
+- Axis
+range: AxisType
+
+```
+</details>

--- a/docs/axis_unit.md
+++ b/docs/axis_unit.md
@@ -1,0 +1,83 @@
+
+
+# Slot: axis_unit
+
+
+_The unit of the axis_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:axis_unit](https://w3id.org/cetmd/entities/:axis_unit)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Axis](Axis.md) | An axis in a coordinate system |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [String](String.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:axis_unit |
+| native | https://w3id.org/cetmd/entities/:axis_unit |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: axis_unit
+description: The unit of the axis
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+ifabsent: angstrom
+alias: axis_unit
+domain_of:
+- Axis
+range: string
+
+```
+</details>

--- a/docs/coordinate_systems.md
+++ b/docs/coordinate_systems.md
@@ -1,0 +1,107 @@
+
+
+# Slot: coordinate_systems
+
+
+_Named coordinate systems for this entity_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:coordinate_systems](https://w3id.org/cetmd/entities/:coordinate_systems)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [CoordMetaMixin](CoordMetaMixin.md) | Coordinate system mixins for annotations |  no  |
+| [Image3D](Image3D.md) | A 3D image |  no  |
+| [PointMatrixSet2D](PointMatrixSet2D.md) | A set of 2D points with an associated rotation matrix |  no  |
+| [ParticleMap](ParticleMap.md) | A 3D particle density map |  no  |
+| [SegmentationMask2D](SegmentationMask2D.md) | An annotation image with categorical labels |  no  |
+| [Tomogram](Tomogram.md) | A 3D tomogram |  no  |
+| [PointMatrixSet3D](PointMatrixSet3D.md) | A set of 3D points with an associated rotation matrix |  no  |
+| [GainFile](GainFile.md) | A gain reference file |  no  |
+| [TriMesh](TriMesh.md) | A mesh annotation |  no  |
+| [SegmentationMask3D](SegmentationMask3D.md) | An annotation volume with categorical labels |  no  |
+| [ProbabilityMap3D](ProbabilityMap3D.md) | An annotation volume with real-valued labels |  no  |
+| [DefectFile](DefectFile.md) | A detector defect file |  no  |
+| [ProbabilityMap2D](ProbabilityMap2D.md) | An annotation image with real-valued labels |  no  |
+| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
+| [PointSet2D](PointSet2D.md) | A set of 2D point annotations |  no  |
+| [PointVectorSet3D](PointVectorSet3D.md) | A set of 3D points with an associated direction vector |  no  |
+| [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
+| [Image2D](Image2D.md) | A 2D image |  no  |
+| [PointVectorSet2D](PointVectorSet2D.md) | A set of 2D points with an associated direction vector |  no  |
+| [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
+| [PointSet3D](PointSet3D.md) | A set of 3D point annotations |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [CoordinateSystem](CoordinateSystem.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:coordinate_systems |
+| native | https://w3id.org/cetmd/entities/:coordinate_systems |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: coordinate_systems
+description: Named coordinate systems for this entity
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: coordinate_systems
+domain_of:
+- Image2D
+- Image3D
+- CoordMetaMixin
+range: CoordinateSystem
+multivalued: true
+
+```
+</details>

--- a/docs/coordinate_systems.md
+++ b/docs/coordinate_systems.md
@@ -23,27 +23,27 @@ URI: [https://w3id.org/cetmd/entities/:coordinate_systems](https://w3id.org/cetm
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [CoordMetaMixin](CoordMetaMixin.md) | Coordinate system mixins for annotations |  no  |
-| [Image3D](Image3D.md) | A 3D image |  no  |
-| [PointMatrixSet2D](PointMatrixSet2D.md) | A set of 2D points with an associated rotation matrix |  no  |
-| [ParticleMap](ParticleMap.md) | A 3D particle density map |  no  |
+| [DefectFile](DefectFile.md) | A detector defect file |  no  |
+| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
+| [TriMesh](TriMesh.md) | A mesh annotation |  no  |
+| [PointMatrixSet3D](PointMatrixSet3D.md) | A set of 3D points with an associated rotation matrix |  no  |
 | [SegmentationMask2D](SegmentationMask2D.md) | An annotation image with categorical labels |  no  |
 | [Tomogram](Tomogram.md) | A 3D tomogram |  no  |
-| [PointMatrixSet3D](PointMatrixSet3D.md) | A set of 3D points with an associated rotation matrix |  no  |
-| [GainFile](GainFile.md) | A gain reference file |  no  |
-| [TriMesh](TriMesh.md) | A mesh annotation |  no  |
 | [SegmentationMask3D](SegmentationMask3D.md) | An annotation volume with categorical labels |  no  |
-| [ProbabilityMap3D](ProbabilityMap3D.md) | An annotation volume with real-valued labels |  no  |
-| [DefectFile](DefectFile.md) | A detector defect file |  no  |
-| [ProbabilityMap2D](ProbabilityMap2D.md) | An annotation image with real-valued labels |  no  |
-| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
+| [Image3D](Image3D.md) | A 3D image |  no  |
 | [PointSet2D](PointSet2D.md) | A set of 2D point annotations |  no  |
-| [PointVectorSet3D](PointVectorSet3D.md) | A set of 3D points with an associated direction vector |  no  |
 | [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
-| [Image2D](Image2D.md) | A 2D image |  no  |
+| [ProbabilityMap3D](ProbabilityMap3D.md) | An annotation volume with real-valued labels |  no  |
+| [PointVectorSet3D](PointVectorSet3D.md) | A set of 3D points with an associated direction vector |  no  |
+| [GainFile](GainFile.md) | A gain reference file |  no  |
 | [PointVectorSet2D](PointVectorSet2D.md) | A set of 2D points with an associated direction vector |  no  |
-| [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
+| [ParticleMap](ParticleMap.md) | A 3D particle density map |  no  |
 | [PointSet3D](PointSet3D.md) | A set of 3D point annotations |  no  |
+| [ProbabilityMap2D](ProbabilityMap2D.md) | An annotation image with real-valued labels |  no  |
+| [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
+| [Image2D](Image2D.md) | A 2D image |  no  |
+| [PointMatrixSet2D](PointMatrixSet2D.md) | A set of 2D points with an associated rotation matrix |  no  |
+| [CoordMetaMixin](CoordMetaMixin.md) | Coordinate system mixins for annotations |  no  |
 
 
 

--- a/docs/coordinate_transformations.md
+++ b/docs/coordinate_transformations.md
@@ -1,0 +1,107 @@
+
+
+# Slot: coordinate_transformations
+
+
+_Named coordinate systems for this entity_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:coordinate_transformations](https://w3id.org/cetmd/entities/:coordinate_transformations)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [CoordMetaMixin](CoordMetaMixin.md) | Coordinate system mixins for annotations |  no  |
+| [Image3D](Image3D.md) | A 3D image |  no  |
+| [PointMatrixSet2D](PointMatrixSet2D.md) | A set of 2D points with an associated rotation matrix |  no  |
+| [ParticleMap](ParticleMap.md) | A 3D particle density map |  no  |
+| [SegmentationMask2D](SegmentationMask2D.md) | An annotation image with categorical labels |  no  |
+| [Tomogram](Tomogram.md) | A 3D tomogram |  no  |
+| [PointMatrixSet3D](PointMatrixSet3D.md) | A set of 3D points with an associated rotation matrix |  no  |
+| [GainFile](GainFile.md) | A gain reference file |  no  |
+| [TriMesh](TriMesh.md) | A mesh annotation |  no  |
+| [SegmentationMask3D](SegmentationMask3D.md) | An annotation volume with categorical labels |  no  |
+| [ProbabilityMap3D](ProbabilityMap3D.md) | An annotation volume with real-valued labels |  no  |
+| [DefectFile](DefectFile.md) | A detector defect file |  no  |
+| [ProbabilityMap2D](ProbabilityMap2D.md) | An annotation image with real-valued labels |  no  |
+| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
+| [PointSet2D](PointSet2D.md) | A set of 2D point annotations |  no  |
+| [PointVectorSet3D](PointVectorSet3D.md) | A set of 3D points with an associated direction vector |  no  |
+| [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
+| [Image2D](Image2D.md) | A 2D image |  no  |
+| [PointVectorSet2D](PointVectorSet2D.md) | A set of 2D points with an associated direction vector |  no  |
+| [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
+| [PointSet3D](PointSet3D.md) | A set of 3D point annotations |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [CoordinateTransformation](CoordinateTransformation.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:coordinate_transformations |
+| native | https://w3id.org/cetmd/entities/:coordinate_transformations |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: coordinate_transformations
+description: Named coordinate systems for this entity
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: coordinate_transformations
+domain_of:
+- Image2D
+- Image3D
+- CoordMetaMixin
+range: CoordinateTransformation
+multivalued: true
+
+```
+</details>

--- a/docs/coordinate_transformations.md
+++ b/docs/coordinate_transformations.md
@@ -23,27 +23,27 @@ URI: [https://w3id.org/cetmd/entities/:coordinate_transformations](https://w3id.
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [CoordMetaMixin](CoordMetaMixin.md) | Coordinate system mixins for annotations |  no  |
-| [Image3D](Image3D.md) | A 3D image |  no  |
-| [PointMatrixSet2D](PointMatrixSet2D.md) | A set of 2D points with an associated rotation matrix |  no  |
-| [ParticleMap](ParticleMap.md) | A 3D particle density map |  no  |
+| [DefectFile](DefectFile.md) | A detector defect file |  no  |
+| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
+| [TriMesh](TriMesh.md) | A mesh annotation |  no  |
+| [PointMatrixSet3D](PointMatrixSet3D.md) | A set of 3D points with an associated rotation matrix |  no  |
 | [SegmentationMask2D](SegmentationMask2D.md) | An annotation image with categorical labels |  no  |
 | [Tomogram](Tomogram.md) | A 3D tomogram |  no  |
-| [PointMatrixSet3D](PointMatrixSet3D.md) | A set of 3D points with an associated rotation matrix |  no  |
-| [GainFile](GainFile.md) | A gain reference file |  no  |
-| [TriMesh](TriMesh.md) | A mesh annotation |  no  |
 | [SegmentationMask3D](SegmentationMask3D.md) | An annotation volume with categorical labels |  no  |
-| [ProbabilityMap3D](ProbabilityMap3D.md) | An annotation volume with real-valued labels |  no  |
-| [DefectFile](DefectFile.md) | A detector defect file |  no  |
-| [ProbabilityMap2D](ProbabilityMap2D.md) | An annotation image with real-valued labels |  no  |
-| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
+| [Image3D](Image3D.md) | A 3D image |  no  |
 | [PointSet2D](PointSet2D.md) | A set of 2D point annotations |  no  |
-| [PointVectorSet3D](PointVectorSet3D.md) | A set of 3D points with an associated direction vector |  no  |
 | [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
-| [Image2D](Image2D.md) | A 2D image |  no  |
+| [ProbabilityMap3D](ProbabilityMap3D.md) | An annotation volume with real-valued labels |  no  |
+| [PointVectorSet3D](PointVectorSet3D.md) | A set of 3D points with an associated direction vector |  no  |
+| [GainFile](GainFile.md) | A gain reference file |  no  |
 | [PointVectorSet2D](PointVectorSet2D.md) | A set of 2D points with an associated direction vector |  no  |
-| [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
+| [ParticleMap](ParticleMap.md) | A 3D particle density map |  no  |
 | [PointSet3D](PointSet3D.md) | A set of 3D point annotations |  no  |
+| [ProbabilityMap2D](ProbabilityMap2D.md) | An annotation image with real-valued labels |  no  |
+| [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
+| [Image2D](Image2D.md) | A 2D image |  no  |
+| [PointMatrixSet2D](PointMatrixSet2D.md) | A set of 2D points with an associated rotation matrix |  no  |
+| [CoordMetaMixin](CoordMetaMixin.md) | Coordinate system mixins for annotations |  no  |
 
 
 

--- a/docs/ctf_metadata.md
+++ b/docs/ctf_metadata.md
@@ -1,0 +1,85 @@
+
+
+# Slot: ctf_metadata
+
+
+_A set of CTF patameters for an image._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:ctf_metadata](https://w3id.org/cetmd/entities/:ctf_metadata)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
+| [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
+| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
+| [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md) | Metadata concerning the acquisition process |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [CTFMetadata](CTFMetadata.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:ctf_metadata |
+| native | https://w3id.org/cetmd/entities/:ctf_metadata |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: ctf_metadata
+description: A set of CTF patameters for an image.
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: ctf_metadata
+domain_of:
+- AcquisitionMetadataMixin
+range: CTFMetadata
+
+```
+</details>

--- a/docs/ctf_metadata.md
+++ b/docs/ctf_metadata.md
@@ -24,9 +24,9 @@ URI: [https://w3id.org/cetmd/entities/:ctf_metadata](https://w3id.org/cetmd/enti
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
 | [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
-| [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
-| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
 | [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md) | Metadata concerning the acquisition process |  no  |
+| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
+| [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
 
 
 

--- a/docs/defect_file.md
+++ b/docs/defect_file.md
@@ -1,0 +1,83 @@
+
+
+# Slot: defect_file
+
+
+_The defect file for the movie stacks_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:defect_file](https://w3id.org/cetmd/entities/:defect_file)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [MovieStackCollection](MovieStackCollection.md) | A collection of movie stacks using the same gain and defect files |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [DefectFile](DefectFile.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:defect_file |
+| native | https://w3id.org/cetmd/entities/:defect_file |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: defect_file
+description: The defect file for the movie stacks
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: defect_file
+owner: MovieStackCollection
+domain_of:
+- MovieStackCollection
+range: DefectFile
+
+```
+</details>

--- a/docs/defocus_angle.md
+++ b/docs/defocus_angle.md
@@ -1,0 +1,82 @@
+
+
+# Slot: defocus_angle
+
+
+_Estimated angle of astigmatism._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:defocus_angle](https://w3id.org/cetmd/entities/:defocus_angle)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [CTFMetadata](CTFMetadata.md) | A set of CTF patameters for an image |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Float](Float.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:defocus_angle |
+| native | https://w3id.org/cetmd/entities/:defocus_angle |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: defocus_angle
+description: Estimated angle of astigmatism.
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: defocus_angle
+domain_of:
+- CTFMetadata
+range: float
+
+```
+</details>

--- a/docs/defocus_u.md
+++ b/docs/defocus_u.md
@@ -1,0 +1,82 @@
+
+
+# Slot: defocus_u
+
+
+_Estimated defocus U for this image in Angstrom, underfocus positive._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:defocus_u](https://w3id.org/cetmd/entities/:defocus_u)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [CTFMetadata](CTFMetadata.md) | A set of CTF patameters for an image |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Float](Float.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:defocus_u |
+| native | https://w3id.org/cetmd/entities/:defocus_u |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: defocus_u
+description: Estimated defocus U for this image in Angstrom, underfocus positive.
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: defocus_u
+domain_of:
+- CTFMetadata
+range: float
+
+```
+</details>

--- a/docs/defocus_v.md
+++ b/docs/defocus_v.md
@@ -1,0 +1,82 @@
+
+
+# Slot: defocus_v
+
+
+_Estimated defocus V for this image in Angstrom, underfocus positive._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:defocus_v](https://w3id.org/cetmd/entities/:defocus_v)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [CTFMetadata](CTFMetadata.md) | A set of CTF patameters for an image |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Float](Float.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:defocus_v |
+| native | https://w3id.org/cetmd/entities/:defocus_v |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: defocus_v
+description: Estimated defocus V for this image in Angstrom, underfocus positive.
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: defocus_v
+domain_of:
+- CTFMetadata
+range: float
+
+```
+</details>

--- a/docs/depth.md
+++ b/docs/depth.md
@@ -1,0 +1,86 @@
+
+
+# Slot: depth
+
+
+_The depth of the image (z-axis) in pixels_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:depth](https://w3id.org/cetmd/entities/:depth)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [SegmentationMask3D](SegmentationMask3D.md) | An annotation volume with categorical labels |  no  |
+| [ProbabilityMap3D](ProbabilityMap3D.md) | An annotation volume with real-valued labels |  no  |
+| [Tomogram](Tomogram.md) | A 3D tomogram |  no  |
+| [Image3D](Image3D.md) | A 3D image |  no  |
+| [ParticleMap](ParticleMap.md) | A 3D particle density map |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Integer](Integer.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:depth |
+| native | https://w3id.org/cetmd/entities/:depth |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: depth
+description: The depth of the image (z-axis) in pixels
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: depth
+domain_of:
+- Image3D
+range: integer
+
+```
+</details>

--- a/docs/depth.md
+++ b/docs/depth.md
@@ -23,11 +23,11 @@ URI: [https://w3id.org/cetmd/entities/:depth](https://w3id.org/cetmd/entities/:d
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [SegmentationMask3D](SegmentationMask3D.md) | An annotation volume with categorical labels |  no  |
+| [ParticleMap](ParticleMap.md) | A 3D particle density map |  no  |
 | [ProbabilityMap3D](ProbabilityMap3D.md) | An annotation volume with real-valued labels |  no  |
 | [Tomogram](Tomogram.md) | A 3D tomogram |  no  |
+| [SegmentationMask3D](SegmentationMask3D.md) | An annotation volume with categorical labels |  no  |
 | [Image3D](Image3D.md) | A 3D image |  no  |
-| [ParticleMap](ParticleMap.md) | A 3D particle density map |  no  |
 
 
 

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -1,0 +1,6 @@
+# entities
+
+Schema for cryoET geometry
+
+URI: https://w3id.org/cetmd/entities
+

--- a/docs/gain_file.md
+++ b/docs/gain_file.md
@@ -1,0 +1,83 @@
+
+
+# Slot: gain_file
+
+
+_The gain file for the movie stacks_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:gain_file](https://w3id.org/cetmd/entities/:gain_file)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [MovieStackCollection](MovieStackCollection.md) | A collection of movie stacks using the same gain and defect files |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [GainFile](GainFile.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:gain_file |
+| native | https://w3id.org/cetmd/entities/:gain_file |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: gain_file
+description: The gain file for the movie stacks
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: gain_file
+owner: MovieStackCollection
+domain_of:
+- MovieStackCollection
+range: GainFile
+
+```
+</details>

--- a/docs/height.md
+++ b/docs/height.md
@@ -1,0 +1,95 @@
+
+
+# Slot: height
+
+
+_The height of the image (y-axis) in pixels_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:height](https://w3id.org/cetmd/entities/:height)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [SegmentationMask3D](SegmentationMask3D.md) | An annotation volume with categorical labels |  no  |
+| [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
+| [Tomogram](Tomogram.md) | A 3D tomogram |  no  |
+| [SegmentationMask2D](SegmentationMask2D.md) | An annotation image with categorical labels |  no  |
+| [ProbabilityMap3D](ProbabilityMap3D.md) | An annotation volume with real-valued labels |  no  |
+| [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
+| [Image2D](Image2D.md) | A 2D image |  no  |
+| [Image3D](Image3D.md) | A 3D image |  no  |
+| [GainFile](GainFile.md) | A gain reference file |  no  |
+| [DefectFile](DefectFile.md) | A detector defect file |  no  |
+| [ProbabilityMap2D](ProbabilityMap2D.md) | An annotation image with real-valued labels |  no  |
+| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
+| [ParticleMap](ParticleMap.md) | A 3D particle density map |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Integer](Integer.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:height |
+| native | https://w3id.org/cetmd/entities/:height |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: height
+description: The height of the image (y-axis) in pixels
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: height
+domain_of:
+- Image2D
+- Image3D
+range: integer
+
+```
+</details>

--- a/docs/height.md
+++ b/docs/height.md
@@ -23,19 +23,19 @@ URI: [https://w3id.org/cetmd/entities/:height](https://w3id.org/cetmd/entities/:
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [SegmentationMask3D](SegmentationMask3D.md) | An annotation volume with categorical labels |  no  |
-| [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
-| [Tomogram](Tomogram.md) | A 3D tomogram |  no  |
-| [SegmentationMask2D](SegmentationMask2D.md) | An annotation image with categorical labels |  no  |
-| [ProbabilityMap3D](ProbabilityMap3D.md) | An annotation volume with real-valued labels |  no  |
-| [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
-| [Image2D](Image2D.md) | A 2D image |  no  |
-| [Image3D](Image3D.md) | A 3D image |  no  |
-| [GainFile](GainFile.md) | A gain reference file |  no  |
 | [DefectFile](DefectFile.md) | A detector defect file |  no  |
-| [ProbabilityMap2D](ProbabilityMap2D.md) | An annotation image with real-valued labels |  no  |
 | [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
 | [ParticleMap](ParticleMap.md) | A 3D particle density map |  no  |
+| [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
+| [ProbabilityMap3D](ProbabilityMap3D.md) | An annotation volume with real-valued labels |  no  |
+| [SegmentationMask2D](SegmentationMask2D.md) | An annotation image with categorical labels |  no  |
+| [Tomogram](Tomogram.md) | A 3D tomogram |  no  |
+| [SegmentationMask3D](SegmentationMask3D.md) | An annotation volume with categorical labels |  no  |
+| [ProbabilityMap2D](ProbabilityMap2D.md) | An annotation image with real-valued labels |  no  |
+| [GainFile](GainFile.md) | A gain reference file |  no  |
+| [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
+| [Image2D](Image2D.md) | A 2D image |  no  |
+| [Image3D](Image3D.md) | A 3D image |  no  |
 
 
 

--- a/docs/images2D.md
+++ b/docs/images2D.md
@@ -1,0 +1,85 @@
+
+
+# Slot: images2D
+
+
+_The images in the stack_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:images2D](https://w3id.org/cetmd/entities/:images2D)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [ImageStack2D](ImageStack2D.md) | A stack of 2D images |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Image2D](Image2D.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:images2D |
+| native | https://w3id.org/cetmd/entities/:images2D |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: images2D
+description: The images in the stack
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: images2D
+domain_of:
+- ImageStack2D
+range: Image2D
+multivalued: true
+
+```
+</details>

--- a/docs/images3D.md
+++ b/docs/images3D.md
@@ -1,0 +1,85 @@
+
+
+# Slot: images3D
+
+
+_The images in the stack_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:images3D](https://w3id.org/cetmd/entities/:images3D)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [ImageStack3D](ImageStack3D.md) | A stack of 3D images |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Image3D](Image3D.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:images3D |
+| native | https://w3id.org/cetmd/entities/:images3D |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: images3D
+description: The images in the stack
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: images3D
+domain_of:
+- ImageStack3D
+range: Image3D
+multivalued: true
+
+```
+</details>

--- a/docs/images_movie.md
+++ b/docs/images_movie.md
@@ -1,0 +1,85 @@
+
+
+# Slot: images_movie
+
+
+_The movie frames in the stack_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:images_movie](https://w3id.org/cetmd/entities/:images_movie)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [MovieStack](MovieStack.md) | A stack of movie frames |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [MovieFrame](MovieFrame.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:images_movie |
+| native | https://w3id.org/cetmd/entities/:images_movie |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: images_movie
+description: The movie frames in the stack
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: images_movie
+domain_of:
+- MovieStack
+range: MovieFrame
+multivalued: true
+
+```
+</details>

--- a/docs/images_tilt.md
+++ b/docs/images_tilt.md
@@ -1,0 +1,85 @@
+
+
+# Slot: images_tilt
+
+
+_The projections in the stack_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:images_tilt](https://w3id.org/cetmd/entities/:images_tilt)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [TiltSeries](TiltSeries.md) | A stack of projection images |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [ProjectionImage](ProjectionImage.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:images_tilt |
+| native | https://w3id.org/cetmd/entities/:images_tilt |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: images_tilt
+description: The projections in the stack
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: images_tilt
+domain_of:
+- TiltSeries
+range: ProjectionImage
+multivalued: true
+
+```
+</details>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,22 +1,159 @@
-# cryoet-metadata
+# entities
 
-A suggestion for a metadata schema for the transfer of cryo-ET geometry metadata between different software tools and
-data repositories.
+Schema for cryoET geometry
 
-## Installation
+URI: https://w3id.org/cetmd/entities
 
-```bash
-git clone
-pip install ".[all]"
-```
+Name: entities
 
-## Build python models from linkML schema
 
-```bash
-make gen-python
-```
 
-## Quick Start
+## Classes
 
-- [Geometry defintions](geometry/geometry_metadata.md)
-- [LinkML schema](linkml/index.md)
+| Class | Description |
+| --- | --- |
+| [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md) | Metadata concerning the acquisition process. |
+| [Alignment](Alignment.md) | The tomographic alignment for a tilt series. |
+| [Annotation](Annotation.md) | A primitive annotation. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[PointMatrixSet2D](PointMatrixSet2D.md) | A set of 2D points with an associated rotation matrix. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[PointMatrixSet3D](PointMatrixSet3D.md) | A set of 3D points with an associated rotation matrix. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[PointSet2D](PointSet2D.md) | A set of 2D point annotations. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[PointSet3D](PointSet3D.md) | A set of 3D point annotations. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[PointVectorSet2D](PointVectorSet2D.md) | A set of 2D points with an associated direction vector. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[PointVectorSet3D](PointVectorSet3D.md) | A set of 3D points with an associated direction vector. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[ProbabilityMap2D](ProbabilityMap2D.md) | An annotation image with real-valued labels. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[ProbabilityMap3D](ProbabilityMap3D.md) | An annotation volume with real-valued labels. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[SegmentationMask2D](SegmentationMask2D.md) | An annotation image with categorical labels. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[SegmentationMask3D](SegmentationMask3D.md) | An annotation volume with categorical labels. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[TriMesh](TriMesh.md) | A mesh annotation. |
+| [Average](Average.md) | A particle averaging experiment. |
+| [Axis](Axis.md) | An axis in a coordinate system |
+| [AxisNameMapping](AxisNameMapping.md) | Axis name to Axis name mapping |
+| [CoordinateSystem](CoordinateSystem.md) | A coordinate system |
+| [CoordinateTransformation](CoordinateTransformation.md) | A coordinate transformation |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Affine](Affine.md) | An affine transformation |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Identity](Identity.md) | The identity transformation |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[MapAxis](MapAxis.md) | Axis permutation transformation |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Scale](Scale.md) | A scaling transformation |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Sequence](Sequence.md) | A sequence of transformations |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[ProjectionAlignment](ProjectionAlignment.md) | The tomographic alignment for a single projection. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Translation](Translation.md) | A translation transformation |
+| [CoordMetaMixin](CoordMetaMixin.md) | Coordinate system mixins for annotations. |
+| [CTFMetadata](CTFMetadata.md) | A set of CTF patameters for an image. |
+| [Dataset](Dataset.md) | A dataset |
+| [Image2D](Image2D.md) | A 2D image. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[DefectFile](DefectFile.md) | A detector defect file. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[GainFile](GainFile.md) | A gain reference file. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[MovieFrame](MovieFrame.md) | An individual movie frame |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[ProjectionImage](ProjectionImage.md) | A projection image. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[SubProjectionImage](SubProjectionImage.md) | A croppecd projection image. |
+| [Image3D](Image3D.md) | A 3D image. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[ParticleMap](ParticleMap.md) | A 3D particle density map. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Tomogram](Tomogram.md) | A 3D tomogram. |
+| [ImageStack2D](ImageStack2D.md) | A stack of 2D images. |
+| [ImageStack3D](ImageStack3D.md) | A stack of 3D images. |
+| [MovieStack](MovieStack.md) | A stack of movie frames. |
+| [MovieStackCollection](MovieStackCollection.md) | A collection of movie stacks using the same gain and defect files. |
+| [MovieStackSeries](MovieStackSeries.md) | A group of movie stacks that belong to a single tilt series. |
+| [Region](Region.md) | Raw data (movie stacks) and derived data (tilt series, tomograms, annotations) from a single region of a specimen. |
+| [TiltSeries](TiltSeries.md) | A stack of projection images. |
+
+
+
+## Slots
+
+| Slot | Description |
+| --- | --- |
+| [accumulated_dose](accumulated_dose.md) | The pre-exposure up to this image in e-/A^2 |
+| [affine](affine.md) | The affine matrix |
+| [alignments](alignments.md) | The alignments |
+| [annotations](annotations.md) | The annotations |
+| [averages](averages.md) | The averages in the dataset |
+| [axes](axes.md) | The axes of the coordinate system |
+| [axis1_name](axis1_name.md) | The type of transformation |
+| [axis2_name](axis2_name.md) | The mapping of the axis names |
+| [axis_name](axis_name.md) | The name of the axis |
+| [axis_type](axis_type.md) | The type of axis |
+| [axis_unit](axis_unit.md) | The unit of the axis |
+| [coordinate_systems](coordinate_systems.md) | Named coordinate systems for this entity |
+| [coordinate_transformations](coordinate_transformations.md) | Named coordinate systems for this entity |
+| [ctf_metadata](ctf_metadata.md) | A set of CTF patameters for an image |
+| [defect_file](defect_file.md) | The defect file for the movie stacks |
+| [defocus_angle](defocus_angle.md) | Estimated angle of astigmatism |
+| [defocus_u](defocus_u.md) | Estimated defocus U for this image in Angstrom, underfocus positive |
+| [defocus_v](defocus_v.md) | Estimated defocus V for this image in Angstrom, underfocus positive |
+| [depth](depth.md) | The depth of the image (z-axis) in pixels |
+| [gain_file](gain_file.md) | The gain file for the movie stacks |
+| [height](height.md) | The height of the image (y-axis) in pixels |
+| [images2D](images2D.md) | The images in the stack |
+| [images3D](images3D.md) | The images in the stack |
+| [images_movie](images_movie.md) | The movie frames in the stack |
+| [images_tilt](images_tilt.md) | The projections in the stack |
+| [input](input.md) | The source coordinate system name |
+| [map_axis](map_axis.md) | The permutation of the axes |
+| [matrix2D](matrix2D.md) | Rotation matrix associated with a point on a 2D image (Nx2x2) |
+| [matrix3D](matrix3D.md) | Rotation matrix associated with a point on a 3D image (Nx3x3) |
+| [movie_stack_collections](movie_stack_collections.md) | The movie stack |
+| [movie_stacks](movie_stacks.md) | The movie stacks in the collection |
+| [name](name.md) | The name of a given entry |
+| [nominal_tilt_angle](nominal_tilt_angle.md) | The tilt angle reported by the microscope |
+| [origin2D](origin2D.md) | Location on a 2D image (Nx2) |
+| [origin3D](origin3D.md) | Location on a 3D image (Nx3) |
+| [output](output.md) | The target coordinate system name |
+| [particle_index](particle_index.md) | Index of a particle inside a tomogram |
+| [particle_maps](particle_maps.md) | The particle maps |
+| [path](path.md) | Path to a file |
+| [projection_alignments](projection_alignments.md) | alignment for a specific projection |
+| [regions](regions.md) | The regions in the dataset |
+| [scale](scale.md) | The scaling vector |
+| [section](section.md) | 0-based section index to the entity inside a stack |
+| [sequence](sequence.md) | The sequence of transformations |
+| [stacks](stacks.md) | The movie stacks |
+| [tilt_series](tilt_series.md) | The tilt series |
+| [tomograms](tomograms.md) | The tomograms |
+| [transformation_type](transformation_type.md) | The type of transformation |
+| [translation](translation.md) | The translation vector |
+| [translation2D](translation2D.md) | Offset from the origin of a point on a 2D image (Nx2) |
+| [translation3D](translation3D.md) | Offset from the origin of a point on a 3D image (Nx3) |
+| [vector2D](vector2D.md) | Orientation vector associated with a point on a 2D image (Nx2) |
+| [vector3D](vector3D.md) | Orientation vector associated with a point on a 3D image (Nx3) |
+| [width](width.md) | The width of the image (x-axis) in pixels |
+
+
+## Enumerations
+
+| Enumeration | Description |
+| --- | --- |
+| [AxisType](AxisType.md) | The type of axis |
+| [TransformationType](TransformationType.md) |  |
+
+
+## Types
+
+| Type | Description |
+| --- | --- |
+| [Boolean](Boolean.md) | A binary (true or false) value |
+| [Curie](Curie.md) | a compact URI |
+| [Date](Date.md) | a date (year, month and day) in an idealized calendar |
+| [DateOrDatetime](DateOrDatetime.md) | Either a date or a datetime |
+| [Datetime](Datetime.md) | The combination of a date and time |
+| [Decimal](Decimal.md) | A real number with arbitrary precision that conforms to the xsd:decimal speci... |
+| [Double](Double.md) | A real number that conforms to the xsd:double specification |
+| [Float](Float.md) | A real number that conforms to the xsd:float specification |
+| [Integer](Integer.md) | An integer |
+| [Jsonpath](Jsonpath.md) | A string encoding a JSON Path |
+| [Jsonpointer](Jsonpointer.md) | A string encoding a JSON Pointer |
+| [Ncname](Ncname.md) | Prefix part of CURIE |
+| [Nodeidentifier](Nodeidentifier.md) | A URI, CURIE or BNODE that represents a node in a model |
+| [Objectidentifier](Objectidentifier.md) | A URI or CURIE that represents an object in the model |
+| [Sparqlpath](Sparqlpath.md) | A string encoding a SPARQL Property Path |
+| [String](String.md) | A character string |
+| [Time](Time.md) | A time object represents a (local) time of day, independent of any particular... |
+| [Uri](Uri.md) | a complete URI |
+| [Uriorcurie](Uriorcurie.md) | a URI or a CURIE |
+
+
+## Subsets
+
+| Subset | Description |
+| --- | --- |

--- a/docs/input.md
+++ b/docs/input.md
@@ -1,0 +1,74 @@
+
+
+# Slot: input
+
+
+
+URI: [https://w3id.org/cetmd/entities/:input](https://w3id.org/cetmd/entities/:input)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Scale](Scale.md) | A scaling transformation |  no  |
+| [Identity](Identity.md) | The identity transformation |  no  |
+| [Translation](Translation.md) | A translation transformation |  no  |
+| [Affine](Affine.md) | An affine transformation |  no  |
+| [MapAxis](MapAxis.md) | Axis permutation transformation |  no  |
+| [Sequence](Sequence.md) | A sequence of transformations |  no  |
+| [CoordinateTransformation](CoordinateTransformation.md) | A coordinate transformation |  no  |
+| [ProjectionAlignment](ProjectionAlignment.md) | The tomographic alignment for a single projection |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: NONE
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:input |
+| native | https://w3id.org/cetmd/entities/:input |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: input
+alias: input
+domain_of:
+- CoordinateTransformation
+- ProjectionAlignment
+
+```
+</details>

--- a/docs/input.md
+++ b/docs/input.md
@@ -18,14 +18,14 @@ URI: [https://w3id.org/cetmd/entities/:input](https://w3id.org/cetmd/entities/:i
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [Scale](Scale.md) | A scaling transformation |  no  |
-| [Identity](Identity.md) | The identity transformation |  no  |
-| [Translation](Translation.md) | A translation transformation |  no  |
-| [Affine](Affine.md) | An affine transformation |  no  |
 | [MapAxis](MapAxis.md) | Axis permutation transformation |  no  |
 | [Sequence](Sequence.md) | A sequence of transformations |  no  |
+| [Identity](Identity.md) | The identity transformation |  no  |
+| [Affine](Affine.md) | An affine transformation |  no  |
 | [CoordinateTransformation](CoordinateTransformation.md) | A coordinate transformation |  no  |
 | [ProjectionAlignment](ProjectionAlignment.md) | The tomographic alignment for a single projection |  no  |
+| [Translation](Translation.md) | A translation transformation |  no  |
+| [Scale](Scale.md) | A scaling transformation |  no  |
 
 
 

--- a/docs/map_axis.md
+++ b/docs/map_axis.md
@@ -1,0 +1,87 @@
+
+
+# Slot: map_axis
+
+
+_The permutation of the axes_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:map_axis](https://w3id.org/cetmd/entities/:map_axis)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [MapAxis](MapAxis.md) | Axis permutation transformation |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [AxisNameMapping](AxisNameMapping.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:map_axis |
+| native | https://w3id.org/cetmd/entities/:map_axis |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: map_axis
+description: The permutation of the axes
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: map_axis
+owner: MapAxis
+domain_of:
+- MapAxis
+range: AxisNameMapping
+multivalued: true
+inlined: true
+
+```
+</details>

--- a/docs/matrix2D.md
+++ b/docs/matrix2D.md
@@ -1,0 +1,91 @@
+
+
+# Slot: matrix2D
+
+
+_Rotation matrix associated with a point on a 2D image (Nx2x2)._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:matrix2D](https://w3id.org/cetmd/entities/:matrix2D)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [PointMatrixSet2D](PointMatrixSet2D.md) | A set of 2D points with an associated rotation matrix |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Float](Float.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:matrix2D |
+| native | https://w3id.org/cetmd/entities/:matrix2D |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: matrix2D
+description: Rotation matrix associated with a point on a 2D image (Nx2x2).
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+array:
+  exact_number_dimensions: 3
+  dimensions:
+  - alias: N
+    minimum_cardinality: 1
+  - alias: xy
+    exact_cardinality: 2
+  - alias: xy
+    exact_cardinality: 2
+alias: matrix2D
+domain_of:
+- PointMatrixSet2D
+range: float
+
+```
+</details>

--- a/docs/matrix3D.md
+++ b/docs/matrix3D.md
@@ -1,0 +1,91 @@
+
+
+# Slot: matrix3D
+
+
+_Rotation matrix associated with a point on a 3D image (Nx3x3)._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:matrix3D](https://w3id.org/cetmd/entities/:matrix3D)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [PointMatrixSet3D](PointMatrixSet3D.md) | A set of 3D points with an associated rotation matrix |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Float](Float.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:matrix3D |
+| native | https://w3id.org/cetmd/entities/:matrix3D |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: matrix3D
+description: Rotation matrix associated with a point on a 3D image (Nx3x3).
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+array:
+  exact_number_dimensions: 3
+  dimensions:
+  - alias: N
+    minimum_cardinality: 1
+  - alias: xyz
+    exact_cardinality: 3
+  - alias: xyz
+    exact_cardinality: 3
+alias: matrix3D
+domain_of:
+- PointMatrixSet3D
+range: float
+
+```
+</details>

--- a/docs/movie_stack_collections.md
+++ b/docs/movie_stack_collections.md
@@ -1,0 +1,86 @@
+
+
+# Slot: movie_stack_collections
+
+
+_The movie stack_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:movie_stack_collections](https://w3id.org/cetmd/entities/:movie_stack_collections)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Region](Region.md) | Raw data (movie stacks) and derived data (tilt series, tomograms, annotations... |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [MovieStackCollection](MovieStackCollection.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:movie_stack_collections |
+| native | https://w3id.org/cetmd/entities/:movie_stack_collections |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: movie_stack_collections
+description: The movie stack
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: movie_stack_collections
+owner: Region
+domain_of:
+- Region
+range: MovieStackCollection
+multivalued: true
+
+```
+</details>

--- a/docs/movie_stacks.md
+++ b/docs/movie_stacks.md
@@ -1,0 +1,86 @@
+
+
+# Slot: movie_stacks
+
+
+_The movie stacks in the collection_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:movie_stacks](https://w3id.org/cetmd/entities/:movie_stacks)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [MovieStackCollection](MovieStackCollection.md) | A collection of movie stacks using the same gain and defect files |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [MovieStackSeries](MovieStackSeries.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:movie_stacks |
+| native | https://w3id.org/cetmd/entities/:movie_stacks |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: movie_stacks
+description: The movie stacks in the collection
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: movie_stacks
+owner: MovieStackCollection
+domain_of:
+- MovieStackCollection
+range: MovieStackSeries
+multivalued: true
+
+```
+</details>

--- a/docs/name.md
+++ b/docs/name.md
@@ -1,0 +1,95 @@
+
+
+# Slot: name
+
+
+_The name of a given entry_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:name](https://w3id.org/cetmd/entities/:name)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [ProjectionAlignment](ProjectionAlignment.md) | The tomographic alignment for a single projection |  no  |
+| [Scale](Scale.md) | A scaling transformation |  no  |
+| [Identity](Identity.md) | The identity transformation |  no  |
+| [Translation](Translation.md) | A translation transformation |  no  |
+| [Dataset](Dataset.md) | A dataset |  no  |
+| [Affine](Affine.md) | An affine transformation |  no  |
+| [MapAxis](MapAxis.md) | Axis permutation transformation |  no  |
+| [Sequence](Sequence.md) | A sequence of transformations |  no  |
+| [CoordinateTransformation](CoordinateTransformation.md) | A coordinate transformation |  no  |
+| [CoordinateSystem](CoordinateSystem.md) | A coordinate system |  no  |
+| [Average](Average.md) | A particle averaging experiment |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [String](String.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:name |
+| native | https://w3id.org/cetmd/entities/:name |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: name
+description: The name of a given entry
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: name
+domain_of:
+- Average
+- Dataset
+- CoordinateSystem
+- CoordinateTransformation
+range: string
+
+```
+</details>

--- a/docs/name.md
+++ b/docs/name.md
@@ -23,17 +23,17 @@ URI: [https://w3id.org/cetmd/entities/:name](https://w3id.org/cetmd/entities/:na
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [ProjectionAlignment](ProjectionAlignment.md) | The tomographic alignment for a single projection |  no  |
-| [Scale](Scale.md) | A scaling transformation |  no  |
-| [Identity](Identity.md) | The identity transformation |  no  |
-| [Translation](Translation.md) | A translation transformation |  no  |
-| [Dataset](Dataset.md) | A dataset |  no  |
-| [Affine](Affine.md) | An affine transformation |  no  |
+| [Average](Average.md) | A particle averaging experiment |  no  |
 | [MapAxis](MapAxis.md) | Axis permutation transformation |  no  |
 | [Sequence](Sequence.md) | A sequence of transformations |  no  |
+| [Identity](Identity.md) | The identity transformation |  no  |
+| [Dataset](Dataset.md) | A dataset |  no  |
+| [Affine](Affine.md) | An affine transformation |  no  |
 | [CoordinateTransformation](CoordinateTransformation.md) | A coordinate transformation |  no  |
 | [CoordinateSystem](CoordinateSystem.md) | A coordinate system |  no  |
-| [Average](Average.md) | A particle averaging experiment |  no  |
+| [ProjectionAlignment](ProjectionAlignment.md) | The tomographic alignment for a single projection |  no  |
+| [Translation](Translation.md) | A translation transformation |  no  |
+| [Scale](Scale.md) | A scaling transformation |  no  |
 
 
 

--- a/docs/nominal_tilt_angle.md
+++ b/docs/nominal_tilt_angle.md
@@ -1,0 +1,85 @@
+
+
+# Slot: nominal_tilt_angle
+
+
+_The tilt angle reported by the microscope_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:nominal_tilt_angle](https://w3id.org/cetmd/entities/:nominal_tilt_angle)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
+| [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
+| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
+| [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md) | Metadata concerning the acquisition process |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Float](Float.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:nominal_tilt_angle |
+| native | https://w3id.org/cetmd/entities/:nominal_tilt_angle |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: nominal_tilt_angle
+description: The tilt angle reported by the microscope
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: nominal_tilt_angle
+domain_of:
+- AcquisitionMetadataMixin
+range: float
+
+```
+</details>

--- a/docs/nominal_tilt_angle.md
+++ b/docs/nominal_tilt_angle.md
@@ -24,9 +24,9 @@ URI: [https://w3id.org/cetmd/entities/:nominal_tilt_angle](https://w3id.org/cetm
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
 | [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
-| [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
-| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
 | [AcquisitionMetadataMixin](AcquisitionMetadataMixin.md) | Metadata concerning the acquisition process |  no  |
+| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
+| [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
 
 
 

--- a/docs/origin2D.md
+++ b/docs/origin2D.md
@@ -1,0 +1,93 @@
+
+
+# Slot: origin2D
+
+
+_Location on a 2D image (Nx2)._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:origin2D](https://w3id.org/cetmd/entities/:origin2D)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [PointMatrixSet2D](PointMatrixSet2D.md) | A set of 2D points with an associated rotation matrix |  no  |
+| [PointVectorSet2D](PointVectorSet2D.md) | A set of 2D points with an associated direction vector |  no  |
+| [PointSet2D](PointSet2D.md) | A set of 2D point annotations |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Float](Float.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:origin2D |
+| native | https://w3id.org/cetmd/entities/:origin2D |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: origin2D
+description: Location on a 2D image (Nx2).
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+array:
+  exact_number_dimensions: 2
+  dimensions:
+  - alias: N
+    minimum_cardinality: 1
+  - alias: xy
+    exact_cardinality: 2
+alias: origin2D
+domain_of:
+- PointSet2D
+- PointVectorSet2D
+- PointMatrixSet2D
+range: float
+
+```
+</details>

--- a/docs/origin2D.md
+++ b/docs/origin2D.md
@@ -23,8 +23,8 @@ URI: [https://w3id.org/cetmd/entities/:origin2D](https://w3id.org/cetmd/entities
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [PointMatrixSet2D](PointMatrixSet2D.md) | A set of 2D points with an associated rotation matrix |  no  |
 | [PointVectorSet2D](PointVectorSet2D.md) | A set of 2D points with an associated direction vector |  no  |
+| [PointMatrixSet2D](PointMatrixSet2D.md) | A set of 2D points with an associated rotation matrix |  no  |
 | [PointSet2D](PointSet2D.md) | A set of 2D point annotations |  no  |
 
 

--- a/docs/origin3D.md
+++ b/docs/origin3D.md
@@ -1,0 +1,93 @@
+
+
+# Slot: origin3D
+
+
+_Location on a 3D image (Nx3)._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:origin3D](https://w3id.org/cetmd/entities/:origin3D)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [PointSet3D](PointSet3D.md) | A set of 3D point annotations |  no  |
+| [PointVectorSet3D](PointVectorSet3D.md) | A set of 3D points with an associated direction vector |  no  |
+| [PointMatrixSet3D](PointMatrixSet3D.md) | A set of 3D points with an associated rotation matrix |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Float](Float.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:origin3D |
+| native | https://w3id.org/cetmd/entities/:origin3D |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: origin3D
+description: Location on a 3D image (Nx3).
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+array:
+  exact_number_dimensions: 2
+  dimensions:
+  - alias: N
+    minimum_cardinality: 1
+  - alias: xyz
+    exact_cardinality: 3
+alias: origin3D
+domain_of:
+- PointSet3D
+- PointVectorSet3D
+- PointMatrixSet3D
+range: float
+
+```
+</details>

--- a/docs/output.md
+++ b/docs/output.md
@@ -1,0 +1,74 @@
+
+
+# Slot: output
+
+
+
+URI: [https://w3id.org/cetmd/entities/:output](https://w3id.org/cetmd/entities/:output)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Scale](Scale.md) | A scaling transformation |  no  |
+| [Identity](Identity.md) | The identity transformation |  no  |
+| [Translation](Translation.md) | A translation transformation |  no  |
+| [Affine](Affine.md) | An affine transformation |  no  |
+| [MapAxis](MapAxis.md) | Axis permutation transformation |  no  |
+| [Sequence](Sequence.md) | A sequence of transformations |  no  |
+| [CoordinateTransformation](CoordinateTransformation.md) | A coordinate transformation |  no  |
+| [ProjectionAlignment](ProjectionAlignment.md) | The tomographic alignment for a single projection |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: NONE
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:output |
+| native | https://w3id.org/cetmd/entities/:output |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: output
+alias: output
+domain_of:
+- CoordinateTransformation
+- ProjectionAlignment
+
+```
+</details>

--- a/docs/output.md
+++ b/docs/output.md
@@ -18,14 +18,14 @@ URI: [https://w3id.org/cetmd/entities/:output](https://w3id.org/cetmd/entities/:
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [Scale](Scale.md) | A scaling transformation |  no  |
-| [Identity](Identity.md) | The identity transformation |  no  |
-| [Translation](Translation.md) | A translation transformation |  no  |
-| [Affine](Affine.md) | An affine transformation |  no  |
 | [MapAxis](MapAxis.md) | Axis permutation transformation |  no  |
 | [Sequence](Sequence.md) | A sequence of transformations |  no  |
+| [Identity](Identity.md) | The identity transformation |  no  |
+| [Affine](Affine.md) | An affine transformation |  no  |
 | [CoordinateTransformation](CoordinateTransformation.md) | A coordinate transformation |  no  |
 | [ProjectionAlignment](ProjectionAlignment.md) | The tomographic alignment for a single projection |  no  |
+| [Translation](Translation.md) | A translation transformation |  no  |
+| [Scale](Scale.md) | A scaling transformation |  no  |
 
 
 

--- a/docs/particle_index.md
+++ b/docs/particle_index.md
@@ -1,0 +1,82 @@
+
+
+# Slot: particle_index
+
+
+_Index of a particle inside a tomogram._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:particle_index](https://w3id.org/cetmd/entities/:particle_index)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Integer](Integer.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:particle_index |
+| native | https://w3id.org/cetmd/entities/:particle_index |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: particle_index
+description: Index of a particle inside a tomogram.
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: particle_index
+domain_of:
+- SubProjectionImage
+range: integer
+
+```
+</details>

--- a/docs/particle_maps.md
+++ b/docs/particle_maps.md
@@ -1,0 +1,86 @@
+
+
+# Slot: particle_maps
+
+
+_The particle maps_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:particle_maps](https://w3id.org/cetmd/entities/:particle_maps)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Average](Average.md) | A particle averaging experiment |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [ParticleMap](ParticleMap.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:particle_maps |
+| native | https://w3id.org/cetmd/entities/:particle_maps |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: particle_maps
+description: The particle maps
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: particle_maps
+owner: Average
+domain_of:
+- Average
+range: ParticleMap
+multivalued: true
+
+```
+</details>

--- a/docs/path.md
+++ b/docs/path.md
@@ -1,0 +1,110 @@
+
+
+# Slot: path
+
+
+_Path to a file._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:path](https://w3id.org/cetmd/entities/:path)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [MovieStack](MovieStack.md) | A stack of movie frames |  no  |
+| [PointMatrixSet2D](PointMatrixSet2D.md) | A set of 2D points with an associated rotation matrix |  no  |
+| [ParticleMap](ParticleMap.md) | A 3D particle density map |  no  |
+| [SegmentationMask2D](SegmentationMask2D.md) | An annotation image with categorical labels |  no  |
+| [Tomogram](Tomogram.md) | A 3D tomogram |  no  |
+| [TiltSeries](TiltSeries.md) | A stack of projection images |  no  |
+| [Annotation](Annotation.md) | A primitive annotation |  no  |
+| [PointMatrixSet3D](PointMatrixSet3D.md) | A set of 3D points with an associated rotation matrix |  no  |
+| [GainFile](GainFile.md) | A gain reference file |  no  |
+| [TriMesh](TriMesh.md) | A mesh annotation |  no  |
+| [SegmentationMask3D](SegmentationMask3D.md) | An annotation volume with categorical labels |  no  |
+| [ProbabilityMap3D](ProbabilityMap3D.md) | An annotation volume with real-valued labels |  no  |
+| [DefectFile](DefectFile.md) | A detector defect file |  no  |
+| [ProbabilityMap2D](ProbabilityMap2D.md) | An annotation image with real-valued labels |  no  |
+| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
+| [PointSet2D](PointSet2D.md) | A set of 2D point annotations |  no  |
+| [PointVectorSet3D](PointVectorSet3D.md) | A set of 3D points with an associated direction vector |  no  |
+| [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
+| [PointVectorSet2D](PointVectorSet2D.md) | A set of 2D points with an associated direction vector |  no  |
+| [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
+| [PointSet3D](PointSet3D.md) | A set of 3D point annotations |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [String](String.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:path |
+| native | https://w3id.org/cetmd/entities/:path |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: path
+description: Path to a file.
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: path
+domain_of:
+- GainFile
+- DefectFile
+- MovieFrame
+- MovieStack
+- ProjectionImage
+- TiltSeries
+- Tomogram
+- ParticleMap
+- Annotation
+range: string
+
+```
+</details>

--- a/docs/path.md
+++ b/docs/path.md
@@ -23,27 +23,27 @@ URI: [https://w3id.org/cetmd/entities/:path](https://w3id.org/cetmd/entities/:pa
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [MovieStack](MovieStack.md) | A stack of movie frames |  no  |
-| [PointMatrixSet2D](PointMatrixSet2D.md) | A set of 2D points with an associated rotation matrix |  no  |
-| [ParticleMap](ParticleMap.md) | A 3D particle density map |  no  |
+| [DefectFile](DefectFile.md) | A detector defect file |  no  |
+| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
+| [TriMesh](TriMesh.md) | A mesh annotation |  no  |
+| [PointMatrixSet3D](PointMatrixSet3D.md) | A set of 3D points with an associated rotation matrix |  no  |
 | [SegmentationMask2D](SegmentationMask2D.md) | An annotation image with categorical labels |  no  |
 | [Tomogram](Tomogram.md) | A 3D tomogram |  no  |
-| [TiltSeries](TiltSeries.md) | A stack of projection images |  no  |
-| [Annotation](Annotation.md) | A primitive annotation |  no  |
-| [PointMatrixSet3D](PointMatrixSet3D.md) | A set of 3D points with an associated rotation matrix |  no  |
-| [GainFile](GainFile.md) | A gain reference file |  no  |
-| [TriMesh](TriMesh.md) | A mesh annotation |  no  |
 | [SegmentationMask3D](SegmentationMask3D.md) | An annotation volume with categorical labels |  no  |
-| [ProbabilityMap3D](ProbabilityMap3D.md) | An annotation volume with real-valued labels |  no  |
-| [DefectFile](DefectFile.md) | A detector defect file |  no  |
-| [ProbabilityMap2D](ProbabilityMap2D.md) | An annotation image with real-valued labels |  no  |
-| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
 | [PointSet2D](PointSet2D.md) | A set of 2D point annotations |  no  |
-| [PointVectorSet3D](PointVectorSet3D.md) | A set of 3D points with an associated direction vector |  no  |
 | [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
+| [ProbabilityMap3D](ProbabilityMap3D.md) | An annotation volume with real-valued labels |  no  |
+| [PointVectorSet3D](PointVectorSet3D.md) | A set of 3D points with an associated direction vector |  no  |
+| [GainFile](GainFile.md) | A gain reference file |  no  |
+| [TiltSeries](TiltSeries.md) | A stack of projection images |  no  |
 | [PointVectorSet2D](PointVectorSet2D.md) | A set of 2D points with an associated direction vector |  no  |
-| [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
+| [ParticleMap](ParticleMap.md) | A 3D particle density map |  no  |
+| [MovieStack](MovieStack.md) | A stack of movie frames |  no  |
 | [PointSet3D](PointSet3D.md) | A set of 3D point annotations |  no  |
+| [Annotation](Annotation.md) | A primitive annotation |  no  |
+| [ProbabilityMap2D](ProbabilityMap2D.md) | An annotation image with real-valued labels |  no  |
+| [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
+| [PointMatrixSet2D](PointMatrixSet2D.md) | A set of 2D points with an associated rotation matrix |  no  |
 
 
 

--- a/docs/projection_alignments.md
+++ b/docs/projection_alignments.md
@@ -1,0 +1,86 @@
+
+
+# Slot: projection_alignments
+
+
+_alignment for a specific projection_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:projection_alignments](https://w3id.org/cetmd/entities/:projection_alignments)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Alignment](Alignment.md) | The tomographic alignment for a tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [ProjectionAlignment](ProjectionAlignment.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:projection_alignments |
+| native | https://w3id.org/cetmd/entities/:projection_alignments |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: projection_alignments
+description: alignment for a specific projection
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: projection_alignments
+owner: Alignment
+domain_of:
+- Alignment
+range: ProjectionAlignment
+multivalued: true
+
+```
+</details>

--- a/docs/regions.md
+++ b/docs/regions.md
@@ -1,0 +1,86 @@
+
+
+# Slot: regions
+
+
+_The regions in the dataset_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:regions](https://w3id.org/cetmd/entities/:regions)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Dataset](Dataset.md) | A dataset |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Region](Region.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:regions |
+| native | https://w3id.org/cetmd/entities/:regions |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: regions
+description: The regions in the dataset
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: regions
+owner: Dataset
+domain_of:
+- Dataset
+range: Region
+multivalued: true
+
+```
+</details>

--- a/docs/section.md
+++ b/docs/section.md
@@ -1,0 +1,85 @@
+
+
+# Slot: section
+
+
+_0-based section index to the entity inside a stack._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:section](https://w3id.org/cetmd/entities/:section)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
+| [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
+| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Integer](Integer.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:section |
+| native | https://w3id.org/cetmd/entities/:section |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: section
+description: 0-based section index to the entity inside a stack.
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: section
+domain_of:
+- MovieFrame
+- ProjectionImage
+range: integer
+
+```
+</details>

--- a/docs/section.md
+++ b/docs/section.md
@@ -24,8 +24,8 @@ URI: [https://w3id.org/cetmd/entities/:section](https://w3id.org/cetmd/entities/
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
 | [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
-| [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
 | [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
+| [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
 
 
 

--- a/docs/stacks.md
+++ b/docs/stacks.md
@@ -1,0 +1,86 @@
+
+
+# Slot: stacks
+
+
+_The movie stacks._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:stacks](https://w3id.org/cetmd/entities/:stacks)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [MovieStackSeries](MovieStackSeries.md) | A group of movie stacks that belong to a single tilt series |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [MovieStack](MovieStack.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:stacks |
+| native | https://w3id.org/cetmd/entities/:stacks |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: stacks
+description: The movie stacks.
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: stacks
+owner: MovieStackSeries
+domain_of:
+- MovieStackSeries
+range: MovieStack
+multivalued: true
+
+```
+</details>

--- a/docs/tilt_series.md
+++ b/docs/tilt_series.md
@@ -1,0 +1,86 @@
+
+
+# Slot: tilt_series
+
+
+_The tilt series_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:tilt_series](https://w3id.org/cetmd/entities/:tilt_series)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Region](Region.md) | Raw data (movie stacks) and derived data (tilt series, tomograms, annotations... |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [TiltSeries](TiltSeries.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:tilt_series |
+| native | https://w3id.org/cetmd/entities/:tilt_series |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: tilt_series
+description: The tilt series
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: tilt_series
+owner: Region
+domain_of:
+- Region
+range: TiltSeries
+multivalued: true
+
+```
+</details>

--- a/docs/tomograms.md
+++ b/docs/tomograms.md
@@ -1,0 +1,86 @@
+
+
+# Slot: tomograms
+
+
+_The tomograms_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:tomograms](https://w3id.org/cetmd/entities/:tomograms)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Region](Region.md) | Raw data (movie stacks) and derived data (tilt series, tomograms, annotations... |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Tomogram](Tomogram.md)
+
+* Multivalued: True
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:tomograms |
+| native | https://w3id.org/cetmd/entities/:tomograms |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: tomograms
+description: The tomograms
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: tomograms
+owner: Region
+domain_of:
+- Region
+range: Tomogram
+multivalued: true
+
+```
+</details>

--- a/docs/transformation_type.md
+++ b/docs/transformation_type.md
@@ -1,0 +1,95 @@
+
+
+# Slot: transformation_type
+
+
+_The type of transformation_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:transformation_type](https://w3id.org/cetmd/entities/:transformation_type)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [Scale](Scale.md) | A scaling transformation |  yes  |
+| [Identity](Identity.md) | The identity transformation |  yes  |
+| [Translation](Translation.md) | A translation transformation |  yes  |
+| [Affine](Affine.md) | An affine transformation |  yes  |
+| [MapAxis](MapAxis.md) | Axis permutation transformation |  yes  |
+| [Sequence](Sequence.md) | A sequence of transformations |  yes  |
+| [CoordinateTransformation](CoordinateTransformation.md) | A coordinate transformation |  no  |
+| [ProjectionAlignment](ProjectionAlignment.md) | The tomographic alignment for a single projection |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [TransformationType](TransformationType.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:transformation_type |
+| native | https://w3id.org/cetmd/entities/:transformation_type |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: transformation_type
+description: The type of transformation
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: transformation_type
+domain_of:
+- CoordinateTransformation
+- Identity
+- MapAxis
+- Translation
+- Scale
+- Affine
+- Sequence
+range: TransformationType
+
+```
+</details>

--- a/docs/transformation_type.md
+++ b/docs/transformation_type.md
@@ -23,14 +23,14 @@ URI: [https://w3id.org/cetmd/entities/:transformation_type](https://w3id.org/cet
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [Scale](Scale.md) | A scaling transformation |  yes  |
-| [Identity](Identity.md) | The identity transformation |  yes  |
-| [Translation](Translation.md) | A translation transformation |  yes  |
-| [Affine](Affine.md) | An affine transformation |  yes  |
 | [MapAxis](MapAxis.md) | Axis permutation transformation |  yes  |
 | [Sequence](Sequence.md) | A sequence of transformations |  yes  |
+| [Identity](Identity.md) | The identity transformation |  yes  |
+| [Affine](Affine.md) | An affine transformation |  yes  |
 | [CoordinateTransformation](CoordinateTransformation.md) | A coordinate transformation |  no  |
 | [ProjectionAlignment](ProjectionAlignment.md) | The tomographic alignment for a single projection |  no  |
+| [Translation](Translation.md) | A translation transformation |  yes  |
+| [Scale](Scale.md) | A scaling transformation |  yes  |
 
 
 

--- a/docs/translation2D.md
+++ b/docs/translation2D.md
@@ -1,0 +1,78 @@
+
+
+# Slot: translation2D
+
+
+_Offset from the origin of a point on a 2D image (Nx2)._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:translation2D](https://w3id.org/cetmd/entities/:translation2D)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Float](Float.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:translation2D |
+| native | https://w3id.org/cetmd/entities/:translation2D |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: translation2D
+description: Offset from the origin of a point on a 2D image (Nx2).
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+array:
+  exact_number_dimensions: 2
+  dimensions:
+  - alias: N
+    minimum_cardinality: 1
+  - alias: xy
+    exact_cardinality: 2
+alias: translation2D
+range: float
+
+```
+</details>

--- a/docs/translation3D.md
+++ b/docs/translation3D.md
@@ -1,0 +1,78 @@
+
+
+# Slot: translation3D
+
+
+_Offset from the origin of a point on a 3D image (Nx3)._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:translation3D](https://w3id.org/cetmd/entities/:translation3D)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Float](Float.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:translation3D |
+| native | https://w3id.org/cetmd/entities/:translation3D |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: translation3D
+description: Offset from the origin of a point on a 3D image (Nx3).
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+array:
+  exact_number_dimensions: 2
+  dimensions:
+  - alias: N
+    minimum_cardinality: 1
+  - alias: xyz
+    exact_cardinality: 3
+alias: translation3D
+range: float
+
+```
+</details>

--- a/docs/vector2D.md
+++ b/docs/vector2D.md
@@ -1,0 +1,89 @@
+
+
+# Slot: vector2D
+
+
+_Orientation vector associated with a point on a 2D image (Nx2)._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:vector2D](https://w3id.org/cetmd/entities/:vector2D)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [PointVectorSet2D](PointVectorSet2D.md) | A set of 2D points with an associated direction vector |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Float](Float.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:vector2D |
+| native | https://w3id.org/cetmd/entities/:vector2D |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: vector2D
+description: Orientation vector associated with a point on a 2D image (Nx2).
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+array:
+  exact_number_dimensions: 2
+  dimensions:
+  - alias: N
+    minimum_cardinality: 1
+  - alias: xy
+    exact_cardinality: 2
+alias: vector2D
+domain_of:
+- PointVectorSet2D
+range: float
+
+```
+</details>

--- a/docs/vector3D.md
+++ b/docs/vector3D.md
@@ -1,0 +1,89 @@
+
+
+# Slot: vector3D
+
+
+_Orientation vector associated with a point on a 3D image (Nx3)._
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:vector3D](https://w3id.org/cetmd/entities/:vector3D)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [PointVectorSet3D](PointVectorSet3D.md) | A set of 3D points with an associated direction vector |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Float](Float.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:vector3D |
+| native | https://w3id.org/cetmd/entities/:vector3D |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: vector3D
+description: Orientation vector associated with a point on a 3D image (Nx3).
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+array:
+  exact_number_dimensions: 2
+  dimensions:
+  - alias: N
+    minimum_cardinality: 1
+  - alias: xyz
+    exact_cardinality: 3
+alias: vector3D
+domain_of:
+- PointVectorSet3D
+range: float
+
+```
+</details>

--- a/docs/width.md
+++ b/docs/width.md
@@ -1,0 +1,95 @@
+
+
+# Slot: width
+
+
+_The width of the image (x-axis) in pixels_
+
+
+
+
+
+URI: [https://w3id.org/cetmd/entities/:width](https://w3id.org/cetmd/entities/:width)
+
+
+
+<!-- no inheritance hierarchy -->
+
+
+
+
+
+## Applicable Classes
+
+| Name | Description | Modifies Slot |
+| --- | --- | --- |
+| [SegmentationMask3D](SegmentationMask3D.md) | An annotation volume with categorical labels |  no  |
+| [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
+| [Tomogram](Tomogram.md) | A 3D tomogram |  no  |
+| [SegmentationMask2D](SegmentationMask2D.md) | An annotation image with categorical labels |  no  |
+| [ProbabilityMap3D](ProbabilityMap3D.md) | An annotation volume with real-valued labels |  no  |
+| [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
+| [Image2D](Image2D.md) | A 2D image |  no  |
+| [Image3D](Image3D.md) | A 3D image |  no  |
+| [GainFile](GainFile.md) | A gain reference file |  no  |
+| [DefectFile](DefectFile.md) | A detector defect file |  no  |
+| [ProbabilityMap2D](ProbabilityMap2D.md) | An annotation image with real-valued labels |  no  |
+| [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
+| [ParticleMap](ParticleMap.md) | A 3D particle density map |  no  |
+
+
+
+
+
+
+
+## Properties
+
+* Range: [Integer](Integer.md)
+
+
+
+
+
+## Identifier and Mapping Information
+
+
+
+
+
+
+
+### Schema Source
+
+
+* from schema: https://w3id.org/cetmd/entities
+
+
+
+
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+| self | https://w3id.org/cetmd/entities/:width |
+| native | https://w3id.org/cetmd/entities/:width |
+
+
+
+
+## LinkML Source
+
+<details>
+```yaml
+name: width
+description: The width of the image (x-axis) in pixels
+from_schema: https://w3id.org/cetmd/entities
+rank: 1000
+alias: width
+domain_of:
+- Image2D
+- Image3D
+range: integer
+
+```
+</details>

--- a/docs/width.md
+++ b/docs/width.md
@@ -23,19 +23,19 @@ URI: [https://w3id.org/cetmd/entities/:width](https://w3id.org/cetmd/entities/:w
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [SegmentationMask3D](SegmentationMask3D.md) | An annotation volume with categorical labels |  no  |
-| [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
-| [Tomogram](Tomogram.md) | A 3D tomogram |  no  |
-| [SegmentationMask2D](SegmentationMask2D.md) | An annotation image with categorical labels |  no  |
-| [ProbabilityMap3D](ProbabilityMap3D.md) | An annotation volume with real-valued labels |  no  |
-| [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
-| [Image2D](Image2D.md) | A 2D image |  no  |
-| [Image3D](Image3D.md) | A 3D image |  no  |
-| [GainFile](GainFile.md) | A gain reference file |  no  |
 | [DefectFile](DefectFile.md) | A detector defect file |  no  |
-| [ProbabilityMap2D](ProbabilityMap2D.md) | An annotation image with real-valued labels |  no  |
 | [SubProjectionImage](SubProjectionImage.md) | A croppecd projection image |  no  |
 | [ParticleMap](ParticleMap.md) | A 3D particle density map |  no  |
+| [MovieFrame](MovieFrame.md) | An individual movie frame |  no  |
+| [ProbabilityMap3D](ProbabilityMap3D.md) | An annotation volume with real-valued labels |  no  |
+| [SegmentationMask2D](SegmentationMask2D.md) | An annotation image with categorical labels |  no  |
+| [Tomogram](Tomogram.md) | A 3D tomogram |  no  |
+| [SegmentationMask3D](SegmentationMask3D.md) | An annotation volume with categorical labels |  no  |
+| [ProbabilityMap2D](ProbabilityMap2D.md) | An annotation image with real-valued labels |  no  |
+| [GainFile](GainFile.md) | A gain reference file |  no  |
+| [ProjectionImage](ProjectionImage.md) | A projection image |  no  |
+| [Image2D](Image2D.md) | A 2D image |  no  |
+| [Image3D](Image3D.md) | A 3D image |  no  |
 
 
 

--- a/entities_merge.yaml
+++ b/entities_merge.yaml
@@ -9,9 +9,6 @@ prefixes:
   image_entities:
     prefix_prefix: image_entities
     prefix_reference: https://w3id.org/cetmd/image_entities/
-  entities:
-    prefix_prefix: entities
-    prefix_reference: https://w3id.org/cetmd/entities/
   annotation:
     prefix_prefix: annotation
     prefix_reference: https://w3id.org/cetmd/annotation/
@@ -39,7 +36,7 @@ prefixes:
   alignment:
     prefix_prefix: alignment
     prefix_reference: https://w3id.org/cetmd/alignment/
-default_prefix: entities
+default_prefix: https://w3id.org/cetmd/entities/
 types:
   string:
     name: string
@@ -4711,3 +4708,4 @@ classes:
         range: ProjectionAlignment
         multivalued: true
 source_file: schema/linkml/entities.yaml
+

--- a/entities_merge.yaml
+++ b/entities_merge.yaml
@@ -6,12 +6,6 @@ prefixes:
   linkml:
     prefix_prefix: linkml
     prefix_reference: https://w3id.org/linkml/
-  image_entities:
-    prefix_prefix: image_entities
-    prefix_reference: https://w3id.org/cetmd/image_entities/
-  annotation:
-    prefix_prefix: annotation
-    prefix_reference: https://w3id.org/cetmd/annotation/
   xsd:
     prefix_prefix: xsd
     prefix_reference: http://www.w3.org/2001/XMLSchema#
@@ -30,6 +24,9 @@ prefixes:
   coord_transforms:
     prefix_prefix: coord_transforms
     prefix_reference: https://w3id.org/cetmd/coord_transforms/
+  image_entities:
+    prefix_prefix: image_entities
+    prefix_reference: https://w3id.org/cetmd/image_entities/
   annotations:
     prefix_prefix: annotations
     prefix_reference: https://w3id.org/cetmd/annotation/
@@ -1138,6 +1135,10 @@ classes:
     - axis_name
     - axis_unit
     - axis_type
+    slot_usage:
+      axis_name:
+        name: axis_name
+        required: true
     attributes:
       axis_name:
         name: axis_name
@@ -1148,6 +1149,7 @@ classes:
         domain_of:
         - Axis
         range: string
+        required: true
       axis_unit:
         name: axis_unit
         description: The unit of the axis

--- a/example.json
+++ b/example.json
@@ -1,0 +1,3072 @@
+{
+    "$defs": {
+        "Acquisition": {
+            "additionalProperties": false,
+            "description": "A set of parameteres describing the data acquisition",
+            "properties": {
+                "beamshift": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/BoundingBox2D"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Movement of the beam above the sample for data collection purposes that does not require movement of the stage. Given in mrad."
+                },
+                "beamtilt": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/BoundingBox2D"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Another way to move the beam above the sample for data collection purposes that does not require movement of the stage. Given in mrad."
+                },
+                "beamtiltgroups": {
+                    "description": "Number of Beamtilt groups present in this dataset - for optimized processing split dataset into groups of same tilt angle. Despite its name Beamshift is often used to achive this result.",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "binning_camera": {
+                    "description": "Level of binning on the images applied during data collection",
+                    "type": "number"
+                },
+                "calibrated_defocus": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Range"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Machine estimated defocus, min and max values in \u00b5m. Has a tendency to be off."
+                },
+                "calibrated_magnification": {
+                    "description": "Calculated magnification, no unit",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "cryogen": {
+                    "description": "Cryogen used in cooling the instrument and sample, usually nitrogen",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date_time": {
+                    "description": "Time and date of the data acquisition",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "detector": {
+                    "description": "Make and model of the detector used",
+                    "type": "string"
+                },
+                "detector_mode": {
+                    "description": "Operating mode of the detector",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "dose_per_movie": {
+                    "$ref": "#/$defs/Any",
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        }
+                    ],
+                    "description": "Average dose per image/movie/tilt - given in electrons per square Angstrom"
+                },
+                "energy_filter": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/EnergyFilter"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Wether an energy filter was used and its specifics."
+                },
+                "exposure_time": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Time of data acquisition per movie/tilt - in s"
+                },
+                "frames_per_movie": {
+                    "description": "Number of frames that on average constitute a full movie, can be a bit hard to define for some detectors",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "gainref_flip_rotate": {
+                    "description": "Whether and how you have to flip or rotate the gainref in order to align with your acquired images",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "grids_imaged": {
+                    "description": "Number of grids imaged for this project - here with qualifier during this data acquisition",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "holder": {
+                    "description": "Speciman holder model",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "holder_cryogen": {
+                    "description": "Type of cryogen used in the holder - if the holder is cooled seperately",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "image_size": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/ImageSize"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The size of the image in pixels, height and width given."
+                },
+                "images_generated": {
+                    "description": "Number of images generated total for this data collection - might need a qualifier for tilt series to determine whether full series or individual tilts are counted",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "imageshift": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/BoundingBox2D"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Movement of the Beam below the image in order to shift the image on the detector. Given in \u00b5m."
+                },
+                "microscope_software": {
+                    "description": "Software used for instrument control,",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "nominal_defocus": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Range"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Target defocus set, min and max values in \u00b5m."
+                },
+                "nominal_magnification": {
+                    "description": "Magnification level as indicated by the instrument, no unit",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "pixel_size": {
+                    "$ref": "#/$defs/Any",
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        }
+                    ],
+                    "description": "Pixel size, in Angstrom"
+                },
+                "specialist_optics": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/SpecialistOptics"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Any type of special optics, such as a phaseplate"
+                },
+                "temperature": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Range"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Temperature during data collection, in K with min and max values."
+                }
+            },
+            "required": [
+                "detector",
+                "dose_per_movie",
+                "date_time",
+                "binning_camera",
+                "pixel_size"
+            ],
+            "title": "Acquisition",
+            "type": "object"
+        },
+        "AcquisitionMetadataMixin": {
+            "additionalProperties": false,
+            "description": "Metadata concerning the acquisition process.",
+            "properties": {
+                "accumulated_dose": {
+                    "description": "The pre-exposure up to this image in e-/A^2",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "ctf_metadata": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/CTFMetadata"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "A set of CTF patameters for an image."
+                },
+                "nominal_tilt_angle": {
+                    "description": "The tilt angle reported by the microscope",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                }
+            },
+            "title": "AcquisitionMetadataMixin",
+            "type": "object"
+        },
+        "AcquisitionTomo": {
+            "additionalProperties": false,
+            "description": "",
+            "properties": {
+                "beamshift": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/BoundingBox2D"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Movement of the beam above the sample for data collection purposes that does not require movement of the stage. Given in mrad."
+                },
+                "beamtilt": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/BoundingBox2D"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Another way to move the beam above the sample for data collection purposes that does not require movement of the stage. Given in mrad."
+                },
+                "beamtiltgroups": {
+                    "description": "Number of Beamtilt groups present in this dataset - for optimized processing split dataset into groups of same tilt angle. Despite its name Beamshift is often used to achive this result.",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "binning_camera": {
+                    "description": "Level of binning on the images applied during data collection",
+                    "type": "number"
+                },
+                "calibrated_defocus": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Range"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Machine estimated defocus, min and max values in \u00b5m. Has a tendency to be off."
+                },
+                "calibrated_magnification": {
+                    "description": "Calculated magnification, no unit",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "cryogen": {
+                    "description": "Cryogen used in cooling the instrument and sample, usually nitrogen",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date_time": {
+                    "description": "Time and date of the data acquisition",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "detector": {
+                    "description": "Make and model of the detector used",
+                    "type": "string"
+                },
+                "detector_mode": {
+                    "description": "Operating mode of the detector",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "dose_per_movie": {
+                    "$ref": "#/$defs/Any",
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        }
+                    ],
+                    "description": "Average dose per image/movie/tilt - given in electrons per square Angstrom"
+                },
+                "energy_filter": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/EnergyFilter"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Wether an energy filter was used and its specifics."
+                },
+                "exposure_time": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Time of data acquisition per movie/tilt - in s"
+                },
+                "frames_per_movie": {
+                    "description": "Number of frames that on average constitute a full movie, can be a bit hard to define for some detectors",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "gainref_flip_rotate": {
+                    "description": "Whether and how you have to flip or rotate the gainref in order to align with your acquired images",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "grids_imaged": {
+                    "description": "Number of grids imaged for this project - here with qualifier during this data acquisition",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "holder": {
+                    "description": "Speciman holder model",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "holder_cryogen": {
+                    "description": "Type of cryogen used in the holder - if the holder is cooled seperately",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "image_size": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/ImageSize"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The size of the image in pixels, height and width given."
+                },
+                "images_generated": {
+                    "description": "Number of images generated total for this data collection - might need a qualifier for tilt series to determine whether full series or individual tilts are counted",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "imageshift": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/BoundingBox2D"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Movement of the Beam below the image in order to shift the image on the detector. Given in \u00b5m."
+                },
+                "microscope_software": {
+                    "description": "Software used for instrument control,",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "nominal_defocus": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Range"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Target defocus set, min and max values in \u00b5m."
+                },
+                "nominal_magnification": {
+                    "description": "Magnification level as indicated by the instrument, no unit",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "pixel_size": {
+                    "$ref": "#/$defs/Any",
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        }
+                    ],
+                    "description": "Pixel size, in Angstrom"
+                },
+                "specialist_optics": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/SpecialistOptics"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Any type of special optics, such as a phaseplate"
+                },
+                "temperature": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Range"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Temperature during data collection, in K with min and max values."
+                },
+                "tilt_angle": {
+                    "$ref": "#/$defs/TiltAngle",
+                    "description": "The min, max and increment of the tilt angle in a tomography session. Unit is degree."
+                },
+                "tilt_axis_angle": {
+                    "description": "The tilt axis angle of a tomography series",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "tilt_axis_angle",
+                "tilt_angle",
+                "detector",
+                "dose_per_movie",
+                "date_time",
+                "binning_camera",
+                "pixel_size"
+            ],
+            "title": "AcquisitionTomo",
+            "type": "object"
+        },
+        "Affine": {
+            "additionalProperties": false,
+            "description": "An affine transformation",
+            "properties": {
+                "affine": {
+                    "items": {
+                        "additionalProperties": true,
+                        "type": [
+                            "null",
+                            "boolean",
+                            "object",
+                            "number",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "input": {
+                    "description": "The source coordinate system name",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "name": {
+                    "description": "The name of the coordinate transformation",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "output": {
+                    "description": "The target coordinate system name",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "transformation_type": {
+                    "$ref": "#/$defs/TransformationType",
+                    "description": "The type of transformation"
+                }
+            },
+            "title": "Affine",
+            "type": "object"
+        },
+        "Alignment": {
+            "additionalProperties": false,
+            "description": "The tomographic alignment for a tilt series.",
+            "properties": {
+                "projection_alignments": {
+                    "description": "alignment for a specific projection",
+                    "items": {
+                        "$ref": "#/$defs/ProjectionAlignment"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                }
+            },
+            "title": "Alignment",
+            "type": "object"
+        },
+        "Annotation": {
+            "additionalProperties": false,
+            "description": "A primitive annotation.",
+            "properties": {
+                "path": {
+                    "description": "Path to a file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "title": "Annotation",
+            "type": "object"
+        },
+        "Any": {
+            "additionalProperties": true,
+            "description": "Any type, used as the base for type-narrowing.",
+            "title": "Any",
+            "type": [
+                "null",
+                "boolean",
+                "object",
+                "number",
+                "string"
+            ]
+        },
+        "Average": {
+            "additionalProperties": false,
+            "description": "A particle averaging experiment.",
+            "properties": {
+                "annotations": {
+                    "description": "The annotations",
+                    "items": {
+                        "$ref": "#/$defs/Annotation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "name": {
+                    "description": "The name of a given entry",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "particle_maps": {
+                    "description": "The particle maps",
+                    "items": {
+                        "$ref": "#/$defs/ParticleMap"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                }
+            },
+            "title": "Average",
+            "type": "object"
+        },
+        "Axis": {
+            "additionalProperties": false,
+            "description": "An axis in a coordinate system",
+            "properties": {
+                "axis_name": {
+                    "description": "The name of the axis",
+                    "type": "string"
+                },
+                "axis_type": {
+                    "$ref": "#/$defs/AxisType",
+                    "description": "The type of axis"
+                },
+                "axis_unit": {
+                    "description": "The unit of the axis",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "axis_name"
+            ],
+            "title": "Axis",
+            "type": "object"
+        },
+        "AxisNameMapping": {
+            "additionalProperties": false,
+            "description": "Axis name to Axis name mapping",
+            "properties": {
+                "axis1_name": {
+                    "description": "The type of transformation",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "axis2_name": {
+                    "description": "The mapping of the axis names",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "title": "AxisNameMapping",
+            "type": "object"
+        },
+        "AxisType": {
+            "description": "The type of axis",
+            "enum": [
+                "space",
+                "array"
+            ],
+            "title": "AxisType",
+            "type": "string"
+        },
+        "BoundingBox2D": {
+            "additionalProperties": false,
+            "description": "an axis-aligned 2D bounding box (float units)",
+            "properties": {
+                "x_max": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "maximum x"
+                },
+                "x_min": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "minimum x"
+                },
+                "y_max": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "maximum y"
+                },
+                "y_min": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "minimum y"
+                }
+            },
+            "title": "BoundingBox2D",
+            "type": "object"
+        },
+        "CTFMetadata": {
+            "additionalProperties": false,
+            "description": "A set of CTF patameters for an image.",
+            "properties": {
+                "defocus_angle": {
+                    "description": "Estimated angle of astigmatism.",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "defocus_u": {
+                    "description": "Estimated defocus U for this image in Angstrom, underfocus positive.",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "defocus_v": {
+                    "description": "Estimated defocus V for this image in Angstrom, underfocus positive.",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                }
+            },
+            "title": "CTFMetadata",
+            "type": "object"
+        },
+        "ChromaticAberrationCorrector": {
+            "additionalProperties": false,
+            "description": "Special device used to correct instrument inherent chromatic aberration.",
+            "properties": {
+                "instrument_type": {
+                    "description": "Details of a given specialist instrument",
+                    "type": "string"
+                },
+                "used": {
+                    "description": "whether a specific instrument was used during data acquisition",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "used",
+                "instrument_type"
+            ],
+            "title": "ChromaticAberrationCorrector",
+            "type": "object"
+        },
+        "CoordMetaMixin": {
+            "additionalProperties": false,
+            "description": "Coordinate system mixins for annotations.",
+            "properties": {
+                "coordinate_systems": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateSystem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "coordinate_transformations": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                }
+            },
+            "title": "CoordMetaMixin",
+            "type": "object"
+        },
+        "CoordinateSystem": {
+            "additionalProperties": false,
+            "description": "A coordinate system",
+            "properties": {
+                "axes": {
+                    "description": "The axes of the coordinate system",
+                    "items": {
+                        "$ref": "#/$defs/Axis"
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "description": "The name of the coordinate system",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "axes"
+            ],
+            "title": "CoordinateSystem",
+            "type": "object"
+        },
+        "CoordinateTransformation": {
+            "additionalProperties": false,
+            "description": "A coordinate transformation",
+            "properties": {
+                "input": {
+                    "description": "The source coordinate system name",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "name": {
+                    "description": "The name of the coordinate transformation",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "output": {
+                    "description": "The target coordinate system name",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "transformation_type": {
+                    "$ref": "#/$defs/TransformationType",
+                    "description": "The type of transformation"
+                }
+            },
+            "title": "CoordinateTransformation",
+            "type": "object"
+        },
+        "DataAcquisition": {
+            "additionalProperties": false,
+            "description": "information about the instrument and the data collection itself",
+            "properties": {
+                "acquisition": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/AcquisitionTomo"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Contains details on data collection parameters"
+                },
+                "instrument": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Instrument"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Contains information regarding instrument constants"
+                }
+            },
+            "title": "DataAcquisition",
+            "type": "object"
+        },
+        "Dataset": {
+            "additionalProperties": false,
+            "description": "A dataset",
+            "properties": {
+                "averages": {
+                    "description": "The averages in the dataset",
+                    "items": {
+                        "$ref": "#/$defs/Average"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "name": {
+                    "description": "The name of a given entry",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "regions": {
+                    "description": "The regions in the dataset",
+                    "items": {
+                        "$ref": "#/$defs/Region"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                }
+            },
+            "title": "Dataset",
+            "type": "object"
+        },
+        "DefectFile": {
+            "additionalProperties": false,
+            "description": "A detector defect file.",
+            "properties": {
+                "coordinate_systems": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateSystem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "coordinate_transformations": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "height": {
+                    "description": "The height of the image (y-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "path": {
+                    "description": "Path to a file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "width": {
+                    "description": "The width of the image (x-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "title": "DefectFile",
+            "type": "object"
+        },
+        "Descriptors": {
+            "additionalProperties": false,
+            "description": "",
+            "properties": {
+                "descriptor_name": {
+                    "description": "Name defining the descriptor",
+                    "type": "string"
+                },
+                "descriptor_thing": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Any"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Description of the descriptor"
+                }
+            },
+            "required": [
+                "descriptor_name"
+            ],
+            "title": "Descriptors",
+            "type": "object"
+        },
+        "EnergyFilter": {
+            "additionalProperties": false,
+            "description": "A device used to filter for electrons with specific energy.",
+            "properties": {
+                "model": {
+                    "description": "Make and model of a specilized device",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "used": {
+                    "description": "whether a specific instrument was used during data acquisition",
+                    "type": "boolean"
+                },
+                "width_energy_filter": {
+                    "$ref": "#/$defs/Any",
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        }
+                    ],
+                    "description": "Width of the energy filter used."
+                }
+            },
+            "required": [
+                "used",
+                "width_energy_filter"
+            ],
+            "title": "EnergyFilter",
+            "type": "object"
+        },
+        "GainFile": {
+            "additionalProperties": false,
+            "description": "A gain reference file.",
+            "properties": {
+                "coordinate_systems": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateSystem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "coordinate_transformations": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "height": {
+                    "description": "The height of the image (y-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "path": {
+                    "description": "Path to a file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "width": {
+                    "description": "The width of the image (x-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "title": "GainFile",
+            "type": "object"
+        },
+        "Identity": {
+            "additionalProperties": false,
+            "description": "The identity transformation",
+            "properties": {
+                "input": {
+                    "description": "The source coordinate system name",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "name": {
+                    "description": "The name of the coordinate transformation",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "output": {
+                    "description": "The target coordinate system name",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "transformation_type": {
+                    "$ref": "#/$defs/TransformationType",
+                    "description": "The type of transformation"
+                }
+            },
+            "title": "Identity",
+            "type": "object"
+        },
+        "Image2D": {
+            "additionalProperties": false,
+            "description": "A 2D image.",
+            "properties": {
+                "coordinate_systems": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateSystem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "coordinate_transformations": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "height": {
+                    "description": "The height of the image (y-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "width": {
+                    "description": "The width of the image (x-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "title": "Image2D",
+            "type": "object"
+        },
+        "Image3D": {
+            "additionalProperties": false,
+            "description": "A 3D image.",
+            "properties": {
+                "coordinate_systems": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateSystem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "coordinate_transformations": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "depth": {
+                    "description": "The depth of the image (z-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "height": {
+                    "description": "The height of the image (y-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "width": {
+                    "description": "The width of the image (x-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "title": "Image3D",
+            "type": "object"
+        },
+        "ImageSize": {
+            "additionalProperties": false,
+            "description": "size of a 2D image (in integer units)",
+            "properties": {
+                "height_im": {
+                    "description": "The height of a given item - unit depends on item",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "width_im": {
+                    "description": "The width of a given item - unit depends on item",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "title": "ImageSize",
+            "type": "object"
+        },
+        "ImageStack2D": {
+            "additionalProperties": false,
+            "description": "A stack of 2D images.",
+            "properties": {
+                "images2D": {
+                    "description": "The images in the stack",
+                    "items": {
+                        "$ref": "#/$defs/Image2D"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                }
+            },
+            "title": "ImageStack2D",
+            "type": "object"
+        },
+        "ImageStack3D": {
+            "additionalProperties": false,
+            "description": "A stack of 3D images.",
+            "properties": {
+                "images3D": {
+                    "description": "The images in the stack",
+                    "items": {
+                        "$ref": "#/$defs/Image3D"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                }
+            },
+            "title": "ImageStack3D",
+            "type": "object"
+        },
+        "Instrument": {
+            "additionalProperties": false,
+            "description": "Instrument values, mostly constant across a data collection.",
+            "properties": {
+                "acceleration_voltage": {
+                    "$ref": "#/$defs/Any",
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        }
+                    ],
+                    "description": "Voltage used for the electron acceleration, in kV"
+                },
+                "c2_aperture": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "C2 aperture size used in data acquisition, in \u00b5m"
+                },
+                "cs": {
+                    "$ref": "#/$defs/Any",
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        }
+                    ],
+                    "description": "Spherical aberration of the instrument, in mm"
+                },
+                "electron_source": {
+                    "description": "Type of electron source used in the microscope, such as FEG",
+                    "type": "string"
+                },
+                "illumination": {
+                    "description": "Mode of illumination used during data collection",
+                    "type": "string"
+                },
+                "imaging": {
+                    "description": "Mode of imaging used during data collection",
+                    "type": "string"
+                },
+                "microscope": {
+                    "description": "Name/Type of the Microscope",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "microscope",
+                "illumination",
+                "imaging",
+                "electron_source",
+                "acceleration_voltage",
+                "cs"
+            ],
+            "title": "Instrument",
+            "type": "object"
+        },
+        "MapAxis": {
+            "additionalProperties": false,
+            "description": "Axis permutation transformation",
+            "properties": {
+                "input": {
+                    "description": "The source coordinate system name",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "map_axis": {
+                    "description": "The permutation of the axes",
+                    "items": {
+                        "$ref": "#/$defs/AxisNameMapping"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "name": {
+                    "description": "The name of the coordinate transformation",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "output": {
+                    "description": "The target coordinate system name",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "transformation_type": {
+                    "$ref": "#/$defs/TransformationType",
+                    "description": "The type of transformation"
+                }
+            },
+            "title": "MapAxis",
+            "type": "object"
+        },
+        "MovieFrame": {
+            "additionalProperties": false,
+            "description": "An individual movie frame",
+            "properties": {
+                "accumulated_dose": {
+                    "description": "The pre-exposure up to this image in e-/A^2",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "coordinate_systems": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateSystem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "coordinate_transformations": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "ctf_metadata": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/CTFMetadata"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "A set of CTF patameters for an image."
+                },
+                "height": {
+                    "description": "The height of the image (y-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "nominal_tilt_angle": {
+                    "description": "The tilt angle reported by the microscope",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "path": {
+                    "description": "Path to a file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "section": {
+                    "description": "0-based section index to the entity inside a stack.",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "width": {
+                    "description": "The width of the image (x-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "title": "MovieFrame",
+            "type": "object"
+        },
+        "MovieStack": {
+            "additionalProperties": false,
+            "description": "A stack of movie frames.",
+            "properties": {
+                "images_movie": {
+                    "description": "The movie frames in the stack",
+                    "items": {
+                        "$ref": "#/$defs/MovieFrame"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "path": {
+                    "description": "Path to a file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "title": "MovieStack",
+            "type": "object"
+        },
+        "MovieStackCollection": {
+            "additionalProperties": false,
+            "description": "A collection of movie stacks using the same gain and defect files.",
+            "properties": {
+                "defect_file": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/DefectFile"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The defect file for the movie stacks"
+                },
+                "gain_file": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/GainFile"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The gain file for the movie stacks"
+                },
+                "movie_stacks": {
+                    "description": "The movie stacks in the collection",
+                    "items": {
+                        "$ref": "#/$defs/MovieStackSeries"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                }
+            },
+            "title": "MovieStackCollection",
+            "type": "object"
+        },
+        "MovieStackSeries": {
+            "additionalProperties": false,
+            "description": "A group of movie stacks that belong to a single tilt series.",
+            "properties": {
+                "stacks": {
+                    "description": "The movie stacks.",
+                    "items": {
+                        "$ref": "#/$defs/MovieStack"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                }
+            },
+            "title": "MovieStackSeries",
+            "type": "object"
+        },
+        "ParticleMap": {
+            "additionalProperties": false,
+            "description": "A 3D particle density map.",
+            "properties": {
+                "coordinate_systems": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateSystem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "coordinate_transformations": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "depth": {
+                    "description": "The depth of the image (z-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "height": {
+                    "description": "The height of the image (y-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "path": {
+                    "description": "Path to a file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "width": {
+                    "description": "The width of the image (x-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "title": "ParticleMap",
+            "type": "object"
+        },
+        "Phaseplate": {
+            "additionalProperties": false,
+            "description": "Used to modulate the phase of the electron wave.",
+            "properties": {
+                "instrument_type": {
+                    "description": "Type of phaseplate",
+                    "type": "string"
+                },
+                "used": {
+                    "description": "whether a specific instrument was used during data acquisition",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "used",
+                "instrument_type"
+            ],
+            "title": "Phaseplate",
+            "type": "object"
+        },
+        "PointMatrixSet2D": {
+            "additionalProperties": false,
+            "description": "A set of 2D points with an associated rotation matrix.",
+            "properties": {
+                "coordinate_systems": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateSystem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "coordinate_transformations": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "matrix2D": {
+                    "items": {
+                        "additionalProperties": true,
+                        "type": [
+                            "null",
+                            "boolean",
+                            "object",
+                            "number",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "origin2D": {
+                    "items": {
+                        "additionalProperties": true,
+                        "type": [
+                            "null",
+                            "boolean",
+                            "object",
+                            "number",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "path": {
+                    "description": "Path to a file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "title": "PointMatrixSet2D",
+            "type": "object"
+        },
+        "PointMatrixSet3D": {
+            "additionalProperties": false,
+            "description": "A set of 3D points with an associated rotation matrix.",
+            "properties": {
+                "coordinate_systems": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateSystem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "coordinate_transformations": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "matrix3D": {
+                    "items": {
+                        "additionalProperties": true,
+                        "type": [
+                            "null",
+                            "boolean",
+                            "object",
+                            "number",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "origin3D": {
+                    "items": {
+                        "additionalProperties": true,
+                        "type": [
+                            "null",
+                            "boolean",
+                            "object",
+                            "number",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "path": {
+                    "description": "Path to a file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "title": "PointMatrixSet3D",
+            "type": "object"
+        },
+        "PointSet2D": {
+            "additionalProperties": false,
+            "description": "A set of 2D point annotations.",
+            "properties": {
+                "coordinate_systems": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateSystem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "coordinate_transformations": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "origin2D": {
+                    "items": {
+                        "additionalProperties": true,
+                        "type": [
+                            "null",
+                            "boolean",
+                            "object",
+                            "number",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "path": {
+                    "description": "Path to a file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "title": "PointSet2D",
+            "type": "object"
+        },
+        "PointSet3D": {
+            "additionalProperties": false,
+            "description": "A set of 3D point annotations.",
+            "properties": {
+                "coordinate_systems": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateSystem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "coordinate_transformations": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "origin3D": {
+                    "items": {
+                        "additionalProperties": true,
+                        "type": [
+                            "null",
+                            "boolean",
+                            "object",
+                            "number",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "path": {
+                    "description": "Path to a file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "title": "PointSet3D",
+            "type": "object"
+        },
+        "PointVectorSet2D": {
+            "additionalProperties": false,
+            "description": "A set of 2D points with an associated direction vector.",
+            "properties": {
+                "coordinate_systems": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateSystem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "coordinate_transformations": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "origin2D": {
+                    "items": {
+                        "additionalProperties": true,
+                        "type": [
+                            "null",
+                            "boolean",
+                            "object",
+                            "number",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "path": {
+                    "description": "Path to a file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "vector2D": {
+                    "items": {
+                        "additionalProperties": true,
+                        "type": [
+                            "null",
+                            "boolean",
+                            "object",
+                            "number",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                }
+            },
+            "title": "PointVectorSet2D",
+            "type": "object"
+        },
+        "PointVectorSet3D": {
+            "additionalProperties": false,
+            "description": "A set of 3D points with an associated direction vector.",
+            "properties": {
+                "coordinate_systems": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateSystem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "coordinate_transformations": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "origin3D": {
+                    "items": {
+                        "additionalProperties": true,
+                        "type": [
+                            "null",
+                            "boolean",
+                            "object",
+                            "number",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "path": {
+                    "description": "Path to a file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "vector3D": {
+                    "items": {
+                        "additionalProperties": true,
+                        "type": [
+                            "null",
+                            "boolean",
+                            "object",
+                            "number",
+                            "string",
+                            "array"
+                        ]
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                }
+            },
+            "title": "PointVectorSet3D",
+            "type": "object"
+        },
+        "ProbabilityMap2D": {
+            "additionalProperties": false,
+            "description": "An annotation image with real-valued labels.",
+            "properties": {
+                "coordinate_systems": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateSystem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "coordinate_transformations": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "height": {
+                    "description": "The height of the image (y-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "path": {
+                    "description": "Path to a file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "width": {
+                    "description": "The width of the image (x-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "title": "ProbabilityMap2D",
+            "type": "object"
+        },
+        "ProbabilityMap3D": {
+            "additionalProperties": false,
+            "description": "An annotation volume with real-valued labels.",
+            "properties": {
+                "coordinate_systems": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateSystem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "coordinate_transformations": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "depth": {
+                    "description": "The depth of the image (z-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "height": {
+                    "description": "The height of the image (y-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "path": {
+                    "description": "Path to a file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "width": {
+                    "description": "The width of the image (x-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "title": "ProbabilityMap3D",
+            "type": "object"
+        },
+        "ProjectionAlignment": {
+            "additionalProperties": false,
+            "description": "The tomographic alignment for a single projection.",
+            "properties": {
+                "input": {
+                    "description": "The source coordinate system name",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "name": {
+                    "description": "The name of the coordinate transformation",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "output": {
+                    "description": "The target coordinate system name",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "sequence": {
+                    "description": "The sequence of transformations",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation",
+                        "anyOf": [
+                            {
+                                "$ref": "#/$defs/Affine"
+                            },
+                            {
+                                "$ref": "#/$defs/Translation"
+                            }
+                        ]
+                    },
+                    "maxItems": 2,
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "transformation_type": {
+                    "$ref": "#/$defs/TransformationType",
+                    "description": "The type of transformation"
+                }
+            },
+            "title": "ProjectionAlignment",
+            "type": "object"
+        },
+        "ProjectionImage": {
+            "additionalProperties": false,
+            "description": "A projection image.",
+            "properties": {
+                "accumulated_dose": {
+                    "description": "The pre-exposure up to this image in e-/A^2",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "coordinate_systems": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateSystem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "coordinate_transformations": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "ctf_metadata": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/CTFMetadata"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "A set of CTF patameters for an image."
+                },
+                "height": {
+                    "description": "The height of the image (y-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "nominal_tilt_angle": {
+                    "description": "The tilt angle reported by the microscope",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "path": {
+                    "description": "Path to a file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "section": {
+                    "description": "0-based section index to the entity inside a stack.",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "width": {
+                    "description": "The width of the image (x-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "title": "ProjectionImage",
+            "type": "object"
+        },
+        "QuantitySI": {
+            "additionalProperties": false,
+            "description": "unit value extended to have two additional fields si_value and si_unit",
+            "properties": {
+                "unit": {
+                    "description": "the unit of a given value",
+                    "type": "string"
+                },
+                "unitSI": {
+                    "description": "the SI unit attached to a si value",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "value": {
+                    "description": "the value of a field with a unit",
+                    "type": "number"
+                },
+                "valueSI": {
+                    "description": "value of a given field in respect to its SI unit",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "unit",
+                "value"
+            ],
+            "title": "QuantitySI",
+            "type": "object"
+        },
+        "QuantityValue": {
+            "additionalProperties": false,
+            "description": "if a value has a unit, it should be given as a unit value pair.",
+            "properties": {
+                "unit": {
+                    "description": "the unit of a given value",
+                    "type": "string"
+                },
+                "value": {
+                    "description": "the value of a field with a unit",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "unit",
+                "value"
+            ],
+            "title": "QuantityValue",
+            "type": "object"
+        },
+        "Range": {
+            "additionalProperties": false,
+            "description": "A range constructed from min and max",
+            "properties": {
+                "maximal": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Maximal value of a given dataset property"
+                },
+                "minimal": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Minimal value of a given dataset property"
+                }
+            },
+            "title": "Range",
+            "type": "object"
+        },
+        "Region": {
+            "additionalProperties": false,
+            "description": "Raw data (movie stacks) and derived data (tilt series, tomograms, annotations) from a single region of a specimen.",
+            "properties": {
+                "alignments": {
+                    "description": "The alignments",
+                    "items": {
+                        "$ref": "#/$defs/Alignment"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "annotations": {
+                    "description": "The annotations",
+                    "items": {
+                        "$ref": "#/$defs/Annotation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "movie_stack_collections": {
+                    "description": "The movie stack",
+                    "items": {
+                        "$ref": "#/$defs/MovieStackCollection"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "tilt_series": {
+                    "description": "The tilt series",
+                    "items": {
+                        "$ref": "#/$defs/TiltSeries"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "tomograms": {
+                    "description": "The tomograms",
+                    "items": {
+                        "$ref": "#/$defs/Tomogram"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                }
+            },
+            "title": "Region",
+            "type": "object"
+        },
+        "Scale": {
+            "additionalProperties": false,
+            "description": "A scaling transformation",
+            "properties": {
+                "input": {
+                    "description": "The source coordinate system name",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "name": {
+                    "description": "The name of the coordinate transformation",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "output": {
+                    "description": "The target coordinate system name",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "scale": {
+                    "description": "The scaling vector",
+                    "items": {
+                        "type": "number"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "transformation_type": {
+                    "$ref": "#/$defs/TransformationType",
+                    "description": "The type of transformation"
+                }
+            },
+            "title": "Scale",
+            "type": "object"
+        },
+        "SegmentationMask2D": {
+            "additionalProperties": false,
+            "description": "An annotation image with categorical labels.",
+            "properties": {
+                "coordinate_systems": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateSystem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "coordinate_transformations": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "height": {
+                    "description": "The height of the image (y-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "path": {
+                    "description": "Path to a file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "width": {
+                    "description": "The width of the image (x-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "title": "SegmentationMask2D",
+            "type": "object"
+        },
+        "SegmentationMask3D": {
+            "additionalProperties": false,
+            "description": "An annotation volume with categorical labels.",
+            "properties": {
+                "coordinate_systems": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateSystem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "coordinate_transformations": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "depth": {
+                    "description": "The depth of the image (z-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "height": {
+                    "description": "The height of the image (y-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "path": {
+                    "description": "Path to a file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "width": {
+                    "description": "The width of the image (x-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "title": "SegmentationMask3D",
+            "type": "object"
+        },
+        "Sequence": {
+            "additionalProperties": false,
+            "description": "A sequence of transformations",
+            "properties": {
+                "input": {
+                    "description": "The source coordinate system name",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "name": {
+                    "description": "The name of the coordinate transformation",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "output": {
+                    "description": "The target coordinate system name",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "sequence": {
+                    "description": "The sequence of transformations",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "transformation_type": {
+                    "$ref": "#/$defs/TransformationType",
+                    "description": "The type of transformation"
+                }
+            },
+            "title": "Sequence",
+            "type": "object"
+        },
+        "Series": {
+            "additionalProperties": false,
+            "description": "A series of numbers constructed from min, max, and increment",
+            "properties": {
+                "increment": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Increment between elements of a series"
+                },
+                "maximal": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Maximal value of a given dataset property"
+                },
+                "minimal": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Minimal value of a given dataset property"
+                }
+            },
+            "title": "Series",
+            "type": "object"
+        },
+        "SpecialistOptics": {
+            "additionalProperties": false,
+            "description": "Optional optics used to correct for instrument limitations.",
+            "properties": {
+                "chromatic_aberration_corrector": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/ChromaticAberrationCorrector"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Specialist device to correct for chromatic aberration of the microscope lenses"
+                },
+                "phaseplate": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Phaseplate"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Phaseplate is a special optics device that can be used to enhance contrast"
+                },
+                "spherical_aberration_corrector": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/SphericalAberrationCorrector"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Specialist device to correct for spherical aberration of the microscope lenses"
+                }
+            },
+            "title": "SpecialistOptics",
+            "type": "object"
+        },
+        "SphericalAberrationCorrector": {
+            "additionalProperties": false,
+            "description": "Special device used to correct instrument inherent spherical aberration.",
+            "properties": {
+                "instrument_type": {
+                    "description": "Details of a given specialist instrument",
+                    "type": "string"
+                },
+                "used": {
+                    "description": "whether a specific instrument was used during data acquisition",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "used",
+                "instrument_type"
+            ],
+            "title": "SphericalAberrationCorrector",
+            "type": "object"
+        },
+        "SubProjectionImage": {
+            "additionalProperties": false,
+            "description": "A croppecd projection image.",
+            "properties": {
+                "accumulated_dose": {
+                    "description": "The pre-exposure up to this image in e-/A^2",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "coordinate_systems": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateSystem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "coordinate_transformations": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "ctf_metadata": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/CTFMetadata"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "A set of CTF patameters for an image."
+                },
+                "height": {
+                    "description": "The height of the image (y-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "nominal_tilt_angle": {
+                    "description": "The tilt angle reported by the microscope",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "particle_index": {
+                    "description": "Index of a particle inside a tomogram.",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "path": {
+                    "description": "Path to a file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "section": {
+                    "description": "0-based section index to the entity inside a stack.",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "width": {
+                    "description": "The width of the image (x-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "title": "SubProjectionImage",
+            "type": "object"
+        },
+        "TiltAngle": {
+            "additionalProperties": false,
+            "description": "The min, max and increment of the tilt angle in a tomography session. Unit is degree.",
+            "properties": {
+                "increment": {
+                    "$ref": "#/$defs/Any",
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        }
+                    ],
+                    "description": "Increment between elements of a series"
+                },
+                "maximal": {
+                    "$ref": "#/$defs/Any",
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        }
+                    ],
+                    "description": "Maximal value of a given dataset property"
+                },
+                "minimal": {
+                    "$ref": "#/$defs/Any",
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QuantityValue"
+                        },
+                        {
+                            "$ref": "#/$defs/QuantitySI"
+                        }
+                    ],
+                    "description": "Minimal value of a given dataset property"
+                }
+            },
+            "required": [
+                "increment",
+                "minimal",
+                "maximal"
+            ],
+            "title": "TiltAngle",
+            "type": "object"
+        },
+        "TiltSeries": {
+            "additionalProperties": false,
+            "description": "A stack of projection images.",
+            "properties": {
+                "images_tilt": {
+                    "description": "The projections in the stack",
+                    "items": {
+                        "$ref": "#/$defs/ProjectionImage"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "path": {
+                    "description": "Path to a file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "title": "TiltSeries",
+            "type": "object"
+        },
+        "Tomogram": {
+            "additionalProperties": false,
+            "description": "A 3D tomogram.",
+            "properties": {
+                "coordinate_systems": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateSystem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "coordinate_transformations": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "depth": {
+                    "description": "The depth of the image (z-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "height": {
+                    "description": "The height of the image (y-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "path": {
+                    "description": "Path to a file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "width": {
+                    "description": "The width of the image (x-axis) in pixels",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "title": "Tomogram",
+            "type": "object"
+        },
+        "TransformationType": {
+            "description": "",
+            "enum": [
+                "identity",
+                "map_axis",
+                "translation",
+                "scale",
+                "affine",
+                "sequence"
+            ],
+            "title": "TransformationType",
+            "type": "string"
+        },
+        "Translation": {
+            "additionalProperties": false,
+            "description": "A translation transformation",
+            "properties": {
+                "input": {
+                    "description": "The source coordinate system name",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "name": {
+                    "description": "The name of the coordinate transformation",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "output": {
+                    "description": "The target coordinate system name",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "transformation_type": {
+                    "$ref": "#/$defs/TransformationType",
+                    "description": "The type of transformation"
+                },
+                "translation": {
+                    "description": "The translation vector",
+                    "items": {
+                        "type": "number"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                }
+            },
+            "title": "Translation",
+            "type": "object"
+        },
+        "TriMesh": {
+            "additionalProperties": false,
+            "description": "A mesh annotation.",
+            "properties": {
+                "coordinate_systems": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateSystem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "coordinate_transformations": {
+                    "description": "Named coordinate systems for this entity",
+                    "items": {
+                        "$ref": "#/$defs/CoordinateTransformation"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "path": {
+                    "description": "Path to a file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "title": "TriMesh",
+            "type": "object"
+        }
+    },
+    "$id": "https://w3id.org/cetmd/entities",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "additionalProperties": true,
+    "metamodel_version": "1.7.0",
+    "title": "entities",
+    "type": "object",
+    "version": "0.0.1"
+}

--- a/merged.yaml
+++ b/merged.yaml
@@ -1,5479 +1,4713 @@
-{
-  "name": "entities",
-  "description": "Schema for cryoET geometry",
-  "id": "https://w3id.org/cetmd/entities",
-  "version": "0.0.1",
-  "prefixes": {
-    "linkml": {
-      "prefix_prefix": "linkml",
-      "prefix_reference": "https://w3id.org/linkml/"
-    },
-    "image_entities": {
-      "prefix_prefix": "image_entities",
-      "prefix_reference": "https://w3id.org/cetmd/image_entities/"
-    },
-    "entities": {
-      "prefix_prefix": "entities",
-      "prefix_reference": "https://w3id.org/cetmd/entities/"
-    },
-    "annotation": {
-      "prefix_prefix": "annotation",
-      "prefix_reference": "https://w3id.org/cetmd/annotation/"
-    },
-    "xsd": {
-      "prefix_prefix": "xsd",
-      "prefix_reference": "http://www.w3.org/2001/XMLSchema#"
-    },
-    "shex": {
-      "prefix_prefix": "shex",
-      "prefix_reference": "http://www.w3.org/ns/shex#"
-    },
-    "schema": {
-      "prefix_prefix": "schema",
-      "prefix_reference": "http://schema.org/"
-    },
-    "image": {
-      "prefix_prefix": "image",
-      "prefix_reference": "https://w3id.org/cetmd/image/"
-    },
-    "coordinate_systems": {
-      "prefix_prefix": "coordinate_systems",
-      "prefix_reference": "https://w3id.org/cetmd/coordinate_systems/"
-    },
-    "coord_transforms": {
-      "prefix_prefix": "coord_transforms",
-      "prefix_reference": "https://w3id.org/cetmd/coord_transforms/"
-    },
-    "annotations": {
-      "prefix_prefix": "annotations",
-      "prefix_reference": "https://w3id.org/cetmd/annotation/"
-    },
-    "alignment": {
-      "prefix_prefix": "alignment",
-      "prefix_reference": "https://w3id.org/cetmd/alignment/"
-    }
-  },
-  "default_prefix": "entities",
-  "types": {
-    "string": {
-      "name": "string",
-      "description": "A character string",
-      "notes": [
-        "In RDF serializations, a slot with range of string is treated as a literal or type xsd:string.   If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"string\"."
-      ],
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "exact_mappings": [
-        "schema:Text"
-      ],
-      "base": "str",
-      "uri": "xsd:string"
-    },
-    "integer": {
-      "name": "integer",
-      "description": "An integer",
-      "notes": [
-        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"integer\"."
-      ],
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "exact_mappings": [
-        "schema:Integer"
-      ],
-      "base": "int",
-      "uri": "xsd:integer"
-    },
-    "boolean": {
-      "name": "boolean",
-      "description": "A binary (true or false) value",
-      "notes": [
-        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"boolean\"."
-      ],
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "exact_mappings": [
-        "schema:Boolean"
-      ],
-      "base": "Bool",
-      "uri": "xsd:boolean",
-      "repr": "bool"
-    },
-    "float": {
-      "name": "float",
-      "description": "A real number that conforms to the xsd:float specification",
-      "notes": [
-        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"float\"."
-      ],
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "exact_mappings": [
-        "schema:Float"
-      ],
-      "base": "float",
-      "uri": "xsd:float"
-    },
-    "double": {
-      "name": "double",
-      "description": "A real number that conforms to the xsd:double specification",
-      "notes": [
-        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"double\"."
-      ],
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "close_mappings": [
-        "schema:Float"
-      ],
-      "base": "float",
-      "uri": "xsd:double"
-    },
-    "decimal": {
-      "name": "decimal",
-      "description": "A real number with arbitrary precision that conforms to the xsd:decimal specification",
-      "notes": [
-        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"decimal\"."
-      ],
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "broad_mappings": [
-        "schema:Number"
-      ],
-      "base": "Decimal",
-      "uri": "xsd:decimal"
-    },
-    "time": {
-      "name": "time",
-      "description": "A time object represents a (local) time of day, independent of any particular day",
-      "notes": [
-        "URI is dateTime because OWL reasoners do not work with straight date or time",
-        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"time\"."
-      ],
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "exact_mappings": [
-        "schema:Time"
-      ],
-      "base": "XSDTime",
-      "uri": "xsd:time",
-      "repr": "str"
-    },
-    "date": {
-      "name": "date",
-      "description": "a date (year, month and day) in an idealized calendar",
-      "notes": [
-        "URI is dateTime because OWL reasoners don't work with straight date or time",
-        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"date\"."
-      ],
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "exact_mappings": [
-        "schema:Date"
-      ],
-      "base": "XSDDate",
-      "uri": "xsd:date",
-      "repr": "str"
-    },
-    "datetime": {
-      "name": "datetime",
-      "description": "The combination of a date and time",
-      "notes": [
-        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"datetime\"."
-      ],
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "exact_mappings": [
-        "schema:DateTime"
-      ],
-      "base": "XSDDateTime",
-      "uri": "xsd:dateTime",
-      "repr": "str"
-    },
-    "date_or_datetime": {
-      "name": "date_or_datetime",
-      "description": "Either a date or a datetime",
-      "notes": [
-        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"date_or_datetime\"."
-      ],
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "base": "str",
-      "uri": "linkml:DateOrDatetime",
-      "repr": "str"
-    },
-    "uriorcurie": {
-      "name": "uriorcurie",
-      "description": "a URI or a CURIE",
-      "notes": [
-        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"uriorcurie\"."
-      ],
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "base": "URIorCURIE",
-      "uri": "xsd:anyURI",
-      "repr": "str"
-    },
-    "curie": {
-      "name": "curie",
-      "conforms_to": "https://www.w3.org/TR/curie/",
-      "description": "a compact URI",
-      "notes": [
-        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"curie\"."
-      ],
-      "comments": [
-        "in RDF serializations this MUST be expanded to a URI",
-        "in non-RDF serializations MAY be serialized as the compact representation"
-      ],
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "base": "Curie",
-      "uri": "xsd:string",
-      "repr": "str"
-    },
-    "uri": {
-      "name": "uri",
-      "conforms_to": "https://www.ietf.org/rfc/rfc3987.txt",
-      "description": "a complete URI",
-      "notes": [
-        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"uri\"."
-      ],
-      "comments": [
-        "in RDF serializations a slot with range of uri is treated as a literal or type xsd:anyURI unless it is an identifier or a reference to an identifier, in which case it is translated directly to a node"
-      ],
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "close_mappings": [
-        "schema:URL"
-      ],
-      "base": "URI",
-      "uri": "xsd:anyURI",
-      "repr": "str"
-    },
-    "ncname": {
-      "name": "ncname",
-      "description": "Prefix part of CURIE",
-      "notes": [
-        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"ncname\"."
-      ],
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "base": "NCName",
-      "uri": "xsd:string",
-      "repr": "str"
-    },
-    "objectidentifier": {
-      "name": "objectidentifier",
-      "description": "A URI or CURIE that represents an object in the model.",
-      "notes": [
-        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"objectidentifier\"."
-      ],
-      "comments": [
-        "Used for inheritance and type checking"
-      ],
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "base": "ElementIdentifier",
-      "uri": "shex:iri",
-      "repr": "str"
-    },
-    "nodeidentifier": {
-      "name": "nodeidentifier",
-      "description": "A URI, CURIE or BNODE that represents a node in a model.",
-      "notes": [
-        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"nodeidentifier\"."
-      ],
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "base": "NodeIdentifier",
-      "uri": "shex:nonLiteral",
-      "repr": "str"
-    },
-    "jsonpointer": {
-      "name": "jsonpointer",
-      "conforms_to": "https://datatracker.ietf.org/doc/html/rfc6901",
-      "description": "A string encoding a JSON Pointer. The value of the string MUST conform to JSON Point syntax and SHOULD dereference to a valid object within the current instance document when encoded in tree form.",
-      "notes": [
-        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"jsonpointer\"."
-      ],
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "base": "str",
-      "uri": "xsd:string",
-      "repr": "str"
-    },
-    "jsonpath": {
-      "name": "jsonpath",
-      "conforms_to": "https://www.ietf.org/archive/id/draft-goessner-dispatch-jsonpath-00.html",
-      "description": "A string encoding a JSON Path. The value of the string MUST conform to JSON Point syntax and SHOULD dereference to zero or more valid objects within the current instance document when encoded in tree form.",
-      "notes": [
-        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"jsonpath\"."
-      ],
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "base": "str",
-      "uri": "xsd:string",
-      "repr": "str"
-    },
-    "sparqlpath": {
-      "name": "sparqlpath",
-      "conforms_to": "https://www.w3.org/TR/sparql11-query/#propertypaths",
-      "description": "A string encoding a SPARQL Property Path. The value of the string MUST conform to SPARQL syntax and SHOULD dereference to zero or more valid objects within the current instance document when encoded as RDF.",
-      "notes": [
-        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"sparqlpath\"."
-      ],
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "base": "str",
-      "uri": "xsd:string",
-      "repr": "str"
-    }
-  },
-  "enums": {
-    "AxisType": {
-      "name": "AxisType",
-      "description": "The type of axis",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "permissible_values": {
-        "space": {
-          "text": "space",
-          "description": "A spatial axis"
-        },
-        "array": {
-          "text": "array",
-          "description": "An array axis"
-        }
-      }
-    },
-    "TransformationType": {
-      "name": "TransformationType",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "permissible_values": {
-        "identity": {
-          "text": "identity",
-          "description": "The identity transformation."
-        },
-        "map_axis": {
-          "text": "map_axis",
-          "description": "Axis permutation transformation"
-        },
-        "translation": {
-          "text": "translation",
-          "description": "A translation transformation."
-        },
-        "scale": {
-          "text": "scale",
-          "description": "A scaling transformation."
-        },
-        "affine": {
-          "text": "affine",
-          "description": "An affine transformation"
-        },
-        "sequence": {
-          "text": "sequence",
-          "description": "A sequence of transformations"
-        }
-      }
-    }
-  },
-  "slots": {
-    "name": {
-      "name": "name",
-      "description": "The name of a given entry",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "Average",
-        "Dataset",
-        "CoordinateSystem",
-        "CoordinateTransformation"
-      ],
-      "range": "string"
-    },
-    "annotations": {
-      "name": "annotations",
-      "description": "The annotations",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "Region",
-        "Average"
-      ],
-      "range": "Annotation",
-      "multivalued": true
-    },
-    "width": {
-      "name": "width",
-      "description": "The width of the image (x-axis) in pixels",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "Image2D",
-        "Image3D",
-        "GainFile",
-        "DefectFile",
-        "MovieFrame",
-        "ProjectionImage",
-        "SubProjectionImage",
-        "Tomogram",
-        "ParticleMap",
-        "SegmentationMask2D",
-        "SegmentationMask3D",
-        "ProbabilityMap2D"
-      ],
-      "range": "integer"
-    },
-    "height": {
-      "name": "height",
-      "description": "The height of the image (y-axis) in pixels",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "Image2D",
-        "Image3D",
-        "GainFile",
-        "DefectFile",
-        "MovieFrame",
-        "ProjectionImage",
-        "SubProjectionImage",
-        "Tomogram",
-        "ParticleMap",
-        "SegmentationMask2D",
-        "SegmentationMask3D",
-        "ProbabilityMap2D"
-      ],
-      "range": "integer"
-    },
-    "depth": {
-      "name": "depth",
-      "description": "The depth of the image (z-axis) in pixels",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "Image3D",
-        "Tomogram",
-        "ParticleMap",
-        "SegmentationMask3D"
-      ],
-      "range": "integer"
-    },
-    "coordinate_systems": {
-      "name": "coordinate_systems",
-      "description": "Named coordinate systems for this entity",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "Image2D",
-        "Image3D",
-        "CoordMetaMixin",
-        "GainFile",
-        "DefectFile",
-        "MovieFrame",
-        "ProjectionImage",
-        "SubProjectionImage",
-        "Tomogram",
-        "ParticleMap",
-        "SegmentationMask2D",
-        "SegmentationMask3D",
-        "ProbabilityMap2D",
-        "ProbabilityMap3D",
-        "PointSet2D",
-        "PointSet3D",
-        "PointVectorSet2D",
-        "PointVectorSet3D",
-        "PointMatrixSet2D",
-        "PointMatrixSet3D"
-      ],
-      "range": "CoordinateSystem",
-      "multivalued": true
-    },
-    "coordinate_transformations": {
-      "name": "coordinate_transformations",
-      "description": "Named coordinate systems for this entity",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "Image2D",
-        "Image3D",
-        "CoordMetaMixin",
-        "GainFile",
-        "DefectFile",
-        "MovieFrame",
-        "ProjectionImage",
-        "SubProjectionImage",
-        "Tomogram",
-        "ParticleMap",
-        "SegmentationMask2D",
-        "SegmentationMask3D",
-        "ProbabilityMap2D",
-        "ProbabilityMap3D",
-        "PointSet2D",
-        "PointSet3D",
-        "PointVectorSet2D",
-        "PointVectorSet3D",
-        "PointMatrixSet2D",
-        "PointMatrixSet3D"
-      ],
-      "range": "CoordinateTransformation",
-      "multivalued": true
-    },
-    "images2D": {
-      "name": "images2D",
-      "description": "The images in the stack",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "ImageStack2D"
-      ],
-      "range": "Image2D",
-      "multivalued": true
-    },
-    "images3D": {
-      "name": "images3D",
-      "description": "The images in the stack",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "ImageStack3D"
-      ],
-      "range": "Image3D",
-      "multivalued": true
-    },
-    "axis_name": {
-      "name": "axis_name",
-      "description": "The name of the axis",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "Axis"
-      ],
-      "range": "string"
-    },
-    "axis_unit": {
-      "name": "axis_unit",
-      "description": "The unit of the axis",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "ifabsent": "angstrom",
-      "domain_of": [
-        "Axis"
-      ],
-      "range": "string"
-    },
-    "axis_type": {
-      "name": "axis_type",
-      "description": "The type of axis",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "Axis"
-      ],
-      "range": "AxisType"
-    },
-    "transformation_type": {
-      "name": "transformation_type",
-      "description": "The type of transformation",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "CoordinateTransformation",
-        "Identity",
-        "MapAxis",
-        "Translation",
-        "Scale",
-        "Affine",
-        "Sequence"
-      ],
-      "range": "TransformationType"
-    },
-    "path": {
-      "name": "path",
-      "description": "Path to a file.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "GainFile",
-        "DefectFile",
-        "MovieFrame",
-        "MovieStack",
-        "ProjectionImage",
-        "TiltSeries",
-        "Tomogram",
-        "ParticleMap",
-        "Annotation",
-        "SubProjectionImage",
-        "SegmentationMask2D",
-        "SegmentationMask3D",
-        "ProbabilityMap2D",
-        "ProbabilityMap3D",
-        "PointSet2D",
-        "PointSet3D",
-        "PointVectorSet2D",
-        "PointVectorSet3D",
-        "PointMatrixSet2D",
-        "PointMatrixSet3D"
-      ],
-      "range": "string"
-    },
-    "section": {
-      "name": "section",
-      "description": "0-based section index to the entity inside a stack.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "MovieFrame",
-        "ProjectionImage"
-      ],
-      "range": "integer"
-    },
-    "nominal_tilt_angle": {
-      "name": "nominal_tilt_angle",
-      "description": "The tilt angle reported by the microscope",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "AcquisitionMetadataMixin",
-        "MovieFrame",
-        "ProjectionImage"
-      ],
-      "range": "float"
-    },
-    "accumulated_dose": {
-      "name": "accumulated_dose",
-      "description": "The pre-exposure up to this image in e-/A^2",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "AcquisitionMetadataMixin",
-        "MovieFrame",
-        "ProjectionImage"
-      ],
-      "range": "float"
-    },
-    "defocus_u": {
-      "name": "defocus_u",
-      "description": "Estimated defocus U for this image in Angstrom, underfocus positive.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "CTFMetadata"
-      ],
-      "range": "float"
-    },
-    "defocus_v": {
-      "name": "defocus_v",
-      "description": "Estimated defocus V for this image in Angstrom, underfocus positive.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "CTFMetadata"
-      ],
-      "range": "float"
-    },
-    "defocus_angle": {
-      "name": "defocus_angle",
-      "description": "Estimated angle of astigmatism.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "CTFMetadata"
-      ],
-      "range": "float"
-    },
-    "particle_index": {
-      "name": "particle_index",
-      "description": "Index of a particle inside a tomogram.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "SubProjectionImage"
-      ],
-      "range": "integer"
-    },
-    "ctf_metadata": {
-      "name": "ctf_metadata",
-      "description": "A set of CTF patameters for an image.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "AcquisitionMetadataMixin",
-        "MovieFrame",
-        "ProjectionImage"
-      ],
-      "range": "CTFMetadata"
-    },
-    "images_movie": {
-      "name": "images_movie",
-      "description": "The movie frames in the stack",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "MovieStack"
-      ],
-      "range": "MovieFrame",
-      "multivalued": true
-    },
-    "images_tilt": {
-      "name": "images_tilt",
-      "description": "The projections in the stack",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "domain_of": [
-        "TiltSeries"
-      ],
-      "range": "ProjectionImage",
-      "multivalued": true
-    },
-    "origin2D": {
-      "name": "origin2D",
-      "description": "Location on a 2D image (Nx2).",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "array": {
-        "exact_number_dimensions": 2,
-        "dimensions": [
-          {
-            "alias": "N",
-            "minimum_cardinality": 1
-          },
-          {
-            "alias": "xy",
-            "exact_cardinality": 2
-          }
-        ]
-      },
-      "domain_of": [
-        "PointSet2D",
-        "PointVectorSet2D",
-        "PointMatrixSet2D"
-      ],
-      "range": "float"
-    },
-    "translation2D": {
-      "name": "translation2D",
-      "description": "Offset from the origin of a point on a 2D image (Nx2).",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "array": {
-        "exact_number_dimensions": 2,
-        "dimensions": [
-          {
-            "alias": "N",
-            "minimum_cardinality": 1
-          },
-          {
-            "alias": "xy",
-            "exact_cardinality": 2
-          }
-        ]
-      },
-      "range": "float"
-    },
-    "vector2D": {
-      "name": "vector2D",
-      "description": "Orientation vector associated with a point on a 2D image (Nx2).",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "array": {
-        "exact_number_dimensions": 2,
-        "dimensions": [
-          {
-            "alias": "N",
-            "minimum_cardinality": 1
-          },
-          {
-            "alias": "xy",
-            "exact_cardinality": 2
-          }
-        ]
-      },
-      "domain_of": [
-        "PointVectorSet2D"
-      ],
-      "range": "float"
-    },
-    "matrix2D": {
-      "name": "matrix2D",
-      "description": "Rotation matrix associated with a point on a 2D image (Nx2x2).",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "array": {
-        "exact_number_dimensions": 3,
-        "dimensions": [
-          {
-            "alias": "N",
-            "minimum_cardinality": 1
-          },
-          {
-            "alias": "xy",
-            "exact_cardinality": 2
-          },
-          {
-            "alias": "xy",
-            "exact_cardinality": 2
-          }
-        ]
-      },
-      "domain_of": [
-        "PointMatrixSet2D"
-      ],
-      "range": "float"
-    },
-    "origin3D": {
-      "name": "origin3D",
-      "description": "Location on a 3D image (Nx3).",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "array": {
-        "exact_number_dimensions": 2,
-        "dimensions": [
-          {
-            "alias": "N",
-            "minimum_cardinality": 1
-          },
-          {
-            "alias": "xyz",
-            "exact_cardinality": 3
-          }
-        ]
-      },
-      "domain_of": [
-        "PointSet3D",
-        "PointVectorSet3D",
-        "PointMatrixSet3D"
-      ],
-      "range": "float"
-    },
-    "translation3D": {
-      "name": "translation3D",
-      "description": "Offset from the origin of a point on a 3D image (Nx3).",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "array": {
-        "exact_number_dimensions": 2,
-        "dimensions": [
-          {
-            "alias": "N",
-            "minimum_cardinality": 1
-          },
-          {
-            "alias": "xyz",
-            "exact_cardinality": 3
-          }
-        ]
-      },
-      "range": "float"
-    },
-    "vector3D": {
-      "name": "vector3D",
-      "description": "Orientation vector associated with a point on a 3D image (Nx3).",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "array": {
-        "exact_number_dimensions": 2,
-        "dimensions": [
-          {
-            "alias": "N",
-            "minimum_cardinality": 1
-          },
-          {
-            "alias": "xyz",
-            "exact_cardinality": 3
-          }
-        ]
-      },
-      "domain_of": [
-        "PointVectorSet3D"
-      ],
-      "range": "float"
-    },
-    "matrix3D": {
-      "name": "matrix3D",
-      "description": "Rotation matrix associated with a point on a 3D image (Nx3x3).",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "array": {
-        "exact_number_dimensions": 3,
-        "dimensions": [
-          {
-            "alias": "N",
-            "minimum_cardinality": 1
-          },
-          {
-            "alias": "xyz",
-            "exact_cardinality": 3
-          },
-          {
-            "alias": "xyz",
-            "exact_cardinality": 3
-          }
-        ]
-      },
-      "domain_of": [
-        "PointMatrixSet3D"
-      ],
-      "range": "float"
-    }
-  },
-  "classes": {
-    "Region": {
-      "name": "Region",
-      "description": "Raw data (movie stacks) and derived data (tilt series, tomograms, annotations) from a single region of a specimen.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "slots": [
-        "annotations"
-      ],
-      "attributes": {
-        "movie_stack_collections": {
-          "name": "movie_stack_collections",
-          "description": "The movie stack",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "movie_stack_collections",
-          "owner": "Region",
-          "domain_of": [
-            "Region"
-          ],
-          "range": "MovieStackCollection",
-          "multivalued": true
-        },
-        "tilt_series": {
-          "name": "tilt_series",
-          "description": "The tilt series",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "tilt_series",
-          "owner": "Region",
-          "domain_of": [
-            "Region"
-          ],
-          "range": "TiltSeries",
-          "multivalued": true
-        },
-        "alignments": {
-          "name": "alignments",
-          "description": "The alignments",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "alignments",
-          "owner": "Region",
-          "domain_of": [
-            "Region"
-          ],
-          "range": "Alignment",
-          "multivalued": true
-        },
-        "tomograms": {
-          "name": "tomograms",
-          "description": "The tomograms",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "tomograms",
-          "owner": "Region",
-          "domain_of": [
-            "Region"
-          ],
-          "range": "Tomogram",
-          "multivalued": true
-        },
-        "annotations": {
-          "name": "annotations",
-          "description": "The annotations",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "annotations",
-          "owner": "Region",
-          "domain_of": [
-            "Region",
-            "Average"
-          ],
-          "range": "Annotation",
-          "multivalued": true
-        }
-      }
-    },
-    "Average": {
-      "name": "Average",
-      "description": "A particle averaging experiment.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "slots": [
-        "name",
-        "annotations"
-      ],
-      "attributes": {
-        "particle_maps": {
-          "name": "particle_maps",
-          "description": "The particle maps",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "particle_maps",
-          "owner": "Average",
-          "domain_of": [
-            "Average"
-          ],
-          "range": "ParticleMap",
-          "multivalued": true
-        },
-        "name": {
-          "name": "name",
-          "description": "The name of a given entry",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "name",
-          "owner": "Average",
-          "domain_of": [
-            "Average",
-            "Dataset",
-            "CoordinateSystem",
-            "CoordinateTransformation"
-          ],
-          "range": "string"
-        },
-        "annotations": {
-          "name": "annotations",
-          "description": "The annotations",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "annotations",
-          "owner": "Average",
-          "domain_of": [
-            "Region",
-            "Average"
-          ],
-          "range": "Annotation",
-          "multivalued": true
-        }
-      }
-    },
-    "MovieStackCollection": {
-      "name": "MovieStackCollection",
-      "description": "A collection of movie stacks using the same gain and defect files.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "attributes": {
-        "movie_stacks": {
-          "name": "movie_stacks",
-          "description": "The movie stacks in the collection",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "movie_stacks",
-          "owner": "MovieStackCollection",
-          "domain_of": [
-            "MovieStackCollection"
-          ],
-          "range": "MovieStackSeries",
-          "multivalued": true
-        },
-        "gain_file": {
-          "name": "gain_file",
-          "description": "The gain file for the movie stacks",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "gain_file",
-          "owner": "MovieStackCollection",
-          "domain_of": [
-            "MovieStackCollection"
-          ],
-          "range": "GainFile"
-        },
-        "defect_file": {
-          "name": "defect_file",
-          "description": "The defect file for the movie stacks",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "defect_file",
-          "owner": "MovieStackCollection",
-          "domain_of": [
-            "MovieStackCollection"
-          ],
-          "range": "DefectFile"
-        }
-      }
-    },
-    "Dataset": {
-      "name": "Dataset",
-      "description": "A dataset",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "slots": [
-        "name"
-      ],
-      "attributes": {
-        "regions": {
-          "name": "regions",
-          "description": "The regions in the dataset",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "regions",
-          "owner": "Dataset",
-          "domain_of": [
-            "Dataset"
-          ],
-          "range": "Region",
-          "multivalued": true
-        },
-        "averages": {
-          "name": "averages",
-          "description": "The averages in the dataset",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "averages",
-          "owner": "Dataset",
-          "domain_of": [
-            "Dataset"
-          ],
-          "range": "Average",
-          "multivalued": true
-        },
-        "name": {
-          "name": "name",
-          "description": "The name of a given entry",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "name",
-          "owner": "Dataset",
-          "domain_of": [
-            "Average",
-            "Dataset",
-            "CoordinateSystem",
-            "CoordinateTransformation"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "Image2D": {
-      "name": "Image2D",
-      "description": "A 2D image.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "slots": [
-        "width",
-        "height",
-        "coordinate_systems",
-        "coordinate_transformations"
-      ],
-      "attributes": {
-        "width": {
-          "name": "width",
-          "description": "The width of the image (x-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "width",
-          "owner": "Image2D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "height": {
-          "name": "height",
-          "description": "The height of the image (y-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "height",
-          "owner": "Image2D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "coordinate_systems": {
-          "name": "coordinate_systems",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_systems",
-          "owner": "Image2D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateSystem",
-          "multivalued": true
-        },
-        "coordinate_transformations": {
-          "name": "coordinate_transformations",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_transformations",
-          "owner": "Image2D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        }
-      }
-    },
-    "Image3D": {
-      "name": "Image3D",
-      "description": "A 3D image.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "slots": [
-        "width",
-        "height",
-        "depth",
-        "coordinate_systems",
-        "coordinate_transformations"
-      ],
-      "attributes": {
-        "width": {
-          "name": "width",
-          "description": "The width of the image (x-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "width",
-          "owner": "Image3D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "height": {
-          "name": "height",
-          "description": "The height of the image (y-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "height",
-          "owner": "Image3D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "depth": {
-          "name": "depth",
-          "description": "The depth of the image (z-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "depth",
-          "owner": "Image3D",
-          "domain_of": [
-            "Image3D",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask3D"
-          ],
-          "range": "integer"
-        },
-        "coordinate_systems": {
-          "name": "coordinate_systems",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_systems",
-          "owner": "Image3D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateSystem",
-          "multivalued": true
-        },
-        "coordinate_transformations": {
-          "name": "coordinate_transformations",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_transformations",
-          "owner": "Image3D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        }
-      }
-    },
-    "ImageStack2D": {
-      "name": "ImageStack2D",
-      "description": "A stack of 2D images.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "slots": [
-        "images2D"
-      ],
-      "attributes": {
-        "images2D": {
-          "name": "images2D",
-          "description": "The images in the stack",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "images2D",
-          "owner": "ImageStack2D",
-          "domain_of": [
-            "ImageStack2D"
-          ],
-          "range": "Image2D",
-          "multivalued": true
-        }
-      }
-    },
-    "ImageStack3D": {
-      "name": "ImageStack3D",
-      "description": "A stack of 3D images.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "slots": [
-        "images3D"
-      ],
-      "attributes": {
-        "images3D": {
-          "name": "images3D",
-          "description": "The images in the stack",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "images3D",
-          "owner": "ImageStack3D",
-          "domain_of": [
-            "ImageStack3D"
-          ],
-          "range": "Image3D",
-          "multivalued": true
-        }
-      }
-    },
-    "Axis": {
-      "name": "Axis",
-      "description": "An axis in a coordinate system",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "slots": [
-        "axis_name",
-        "axis_unit",
-        "axis_type"
-      ],
-      "attributes": {
-        "axis_name": {
-          "name": "axis_name",
-          "description": "The name of the axis",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "axis_name",
-          "owner": "Axis",
-          "domain_of": [
-            "Axis"
-          ],
-          "range": "string"
-        },
-        "axis_unit": {
-          "name": "axis_unit",
-          "description": "The unit of the axis",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "ifabsent": "angstrom",
-          "alias": "axis_unit",
-          "owner": "Axis",
-          "domain_of": [
-            "Axis"
-          ],
-          "range": "string"
-        },
-        "axis_type": {
-          "name": "axis_type",
-          "description": "The type of axis",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "axis_type",
-          "owner": "Axis",
-          "domain_of": [
-            "Axis"
-          ],
-          "range": "AxisType"
-        }
-      }
-    },
-    "CoordinateSystem": {
-      "name": "CoordinateSystem",
-      "description": "A coordinate system",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "attributes": {
-        "name": {
-          "name": "name",
-          "description": "The name of the coordinate system",
-          "from_schema": "https://w3id.org/cetmd/coordinate_systems",
-          "alias": "name",
-          "owner": "CoordinateSystem",
-          "domain_of": [
-            "Average",
-            "Dataset",
-            "CoordinateSystem",
-            "CoordinateTransformation"
-          ],
-          "range": "string",
-          "required": true
-        },
-        "axes": {
-          "name": "axes",
-          "description": "The axes of the coordinate system",
-          "from_schema": "https://w3id.org/cetmd/coordinate_systems",
-          "alias": "axes",
-          "owner": "CoordinateSystem",
-          "domain_of": [
-            "CoordinateSystem"
-          ],
-          "range": "Axis",
-          "required": true,
-          "multivalued": true
-        }
-      }
-    },
-    "CoordinateTransformation": {
-      "name": "CoordinateTransformation",
-      "description": "A coordinate transformation",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "slots": [
-        "transformation_type"
-      ],
-      "attributes": {
-        "name": {
-          "name": "name",
-          "description": "The name of the coordinate transformation",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "name",
-          "owner": "CoordinateTransformation",
-          "domain_of": [
-            "Average",
-            "Dataset",
-            "CoordinateSystem",
-            "CoordinateTransformation",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine",
-            "Sequence"
-          ],
-          "range": "string"
-        },
-        "input": {
-          "name": "input",
-          "description": "The source coordinate system name",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "input",
-          "owner": "CoordinateTransformation",
-          "domain_of": [
-            "CoordinateTransformation",
-            "ProjectionAlignment",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine"
-          ],
-          "range": "string"
-        },
-        "output": {
-          "name": "output",
-          "description": "The target coordinate system name",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "output",
-          "owner": "CoordinateTransformation",
-          "domain_of": [
-            "CoordinateTransformation",
-            "ProjectionAlignment",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine"
-          ],
-          "range": "string"
-        },
-        "transformation_type": {
-          "name": "transformation_type",
-          "description": "The type of transformation",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "transformation_type",
-          "owner": "CoordinateTransformation",
-          "domain_of": [
-            "CoordinateTransformation",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine",
-            "Sequence"
-          ],
-          "range": "TransformationType"
-        }
-      }
-    },
-    "Identity": {
-      "name": "Identity",
-      "description": "The identity transformation",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "CoordinateTransformation",
-      "slots": [
-        "transformation_type"
-      ],
-      "slot_usage": {
-        "transformation_type": {
-          "name": "transformation_type",
-          "ifabsent": "identity"
-        }
-      },
-      "attributes": {
-        "transformation_type": {
-          "name": "transformation_type",
-          "description": "The type of transformation",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "ifabsent": "identity",
-          "alias": "transformation_type",
-          "owner": "Identity",
-          "domain_of": [
-            "CoordinateTransformation",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine",
-            "Sequence"
-          ],
-          "range": "TransformationType"
-        },
-        "name": {
-          "name": "name",
-          "description": "The name of the coordinate transformation",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "name",
-          "owner": "Identity",
-          "domain_of": [
-            "Average",
-            "Dataset",
-            "CoordinateSystem",
-            "CoordinateTransformation",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine",
-            "Sequence"
-          ],
-          "range": "string"
-        },
-        "input": {
-          "name": "input",
-          "description": "The source coordinate system name",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "input",
-          "owner": "Identity",
-          "domain_of": [
-            "CoordinateTransformation",
-            "ProjectionAlignment",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine"
-          ],
-          "range": "string"
-        },
-        "output": {
-          "name": "output",
-          "description": "The target coordinate system name",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "output",
-          "owner": "Identity",
-          "domain_of": [
-            "CoordinateTransformation",
-            "ProjectionAlignment",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "AxisNameMapping": {
-      "name": "AxisNameMapping",
-      "description": "Axis name to Axis name mapping",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "attributes": {
-        "axis1_name": {
-          "name": "axis1_name",
-          "description": "The type of transformation",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "axis1_name",
-          "owner": "AxisNameMapping",
-          "domain_of": [
-            "AxisNameMapping"
-          ],
-          "range": "string"
-        },
-        "axis2_name": {
-          "name": "axis2_name",
-          "description": "The mapping of the axis names",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "axis2_name",
-          "owner": "AxisNameMapping",
-          "domain_of": [
-            "AxisNameMapping"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "MapAxis": {
-      "name": "MapAxis",
-      "description": "Axis permutation transformation",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "CoordinateTransformation",
-      "slots": [
-        "transformation_type"
-      ],
-      "slot_usage": {
-        "transformation_type": {
-          "name": "transformation_type",
-          "ifabsent": "map_axis"
-        }
-      },
-      "attributes": {
-        "map_axis": {
-          "name": "map_axis",
-          "description": "The permutation of the axes",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "map_axis",
-          "owner": "MapAxis",
-          "domain_of": [
-            "MapAxis"
-          ],
-          "range": "AxisNameMapping",
-          "multivalued": true,
-          "inlined": true
-        },
-        "transformation_type": {
-          "name": "transformation_type",
-          "description": "The type of transformation",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "ifabsent": "map_axis",
-          "alias": "transformation_type",
-          "owner": "MapAxis",
-          "domain_of": [
-            "CoordinateTransformation",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine",
-            "Sequence"
-          ],
-          "range": "TransformationType"
-        },
-        "name": {
-          "name": "name",
-          "description": "The name of the coordinate transformation",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "name",
-          "owner": "MapAxis",
-          "domain_of": [
-            "Average",
-            "Dataset",
-            "CoordinateSystem",
-            "CoordinateTransformation",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine",
-            "Sequence"
-          ],
-          "range": "string"
-        },
-        "input": {
-          "name": "input",
-          "description": "The source coordinate system name",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "input",
-          "owner": "MapAxis",
-          "domain_of": [
-            "CoordinateTransformation",
-            "ProjectionAlignment",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine"
-          ],
-          "range": "string"
-        },
-        "output": {
-          "name": "output",
-          "description": "The target coordinate system name",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "output",
-          "owner": "MapAxis",
-          "domain_of": [
-            "CoordinateTransformation",
-            "ProjectionAlignment",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "Translation": {
-      "name": "Translation",
-      "description": "A translation transformation",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "CoordinateTransformation",
-      "slots": [
-        "transformation_type"
-      ],
-      "slot_usage": {
-        "transformation_type": {
-          "name": "transformation_type",
-          "ifabsent": "translation"
-        }
-      },
-      "attributes": {
-        "translation": {
-          "name": "translation",
-          "description": "The translation vector",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "translation",
-          "owner": "Translation",
-          "domain_of": [
-            "Translation"
-          ],
-          "range": "float",
-          "multivalued": true
-        },
-        "transformation_type": {
-          "name": "transformation_type",
-          "description": "The type of transformation",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "ifabsent": "translation",
-          "alias": "transformation_type",
-          "owner": "Translation",
-          "domain_of": [
-            "CoordinateTransformation",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine",
-            "Sequence"
-          ],
-          "range": "TransformationType"
-        },
-        "name": {
-          "name": "name",
-          "description": "The name of the coordinate transformation",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "name",
-          "owner": "Translation",
-          "domain_of": [
-            "Average",
-            "Dataset",
-            "CoordinateSystem",
-            "CoordinateTransformation",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine",
-            "Sequence"
-          ],
-          "range": "string"
-        },
-        "input": {
-          "name": "input",
-          "description": "The source coordinate system name",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "input",
-          "owner": "Translation",
-          "domain_of": [
-            "CoordinateTransformation",
-            "ProjectionAlignment",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine"
-          ],
-          "range": "string"
-        },
-        "output": {
-          "name": "output",
-          "description": "The target coordinate system name",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "output",
-          "owner": "Translation",
-          "domain_of": [
-            "CoordinateTransformation",
-            "ProjectionAlignment",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "Scale": {
-      "name": "Scale",
-      "description": "A scaling transformation",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "CoordinateTransformation",
-      "slots": [
-        "transformation_type"
-      ],
-      "slot_usage": {
-        "transformation_type": {
-          "name": "transformation_type",
-          "ifabsent": "scale"
-        }
-      },
-      "attributes": {
-        "scale": {
-          "name": "scale",
-          "description": "The scaling vector",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "scale",
-          "owner": "Scale",
-          "domain_of": [
-            "Scale"
-          ],
-          "range": "float",
-          "multivalued": true
-        },
-        "transformation_type": {
-          "name": "transformation_type",
-          "description": "The type of transformation",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "ifabsent": "scale",
-          "alias": "transformation_type",
-          "owner": "Scale",
-          "domain_of": [
-            "CoordinateTransformation",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine",
-            "Sequence"
-          ],
-          "range": "TransformationType"
-        },
-        "name": {
-          "name": "name",
-          "description": "The name of the coordinate transformation",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "name",
-          "owner": "Scale",
-          "domain_of": [
-            "Average",
-            "Dataset",
-            "CoordinateSystem",
-            "CoordinateTransformation",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine",
-            "Sequence"
-          ],
-          "range": "string"
-        },
-        "input": {
-          "name": "input",
-          "description": "The source coordinate system name",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "input",
-          "owner": "Scale",
-          "domain_of": [
-            "CoordinateTransformation",
-            "ProjectionAlignment",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine"
-          ],
-          "range": "string"
-        },
-        "output": {
-          "name": "output",
-          "description": "The target coordinate system name",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "output",
-          "owner": "Scale",
-          "domain_of": [
-            "CoordinateTransformation",
-            "ProjectionAlignment",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "Affine": {
-      "name": "Affine",
-      "description": "An affine transformation",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "CoordinateTransformation",
-      "slots": [
-        "transformation_type"
-      ],
-      "slot_usage": {
-        "transformation_type": {
-          "name": "transformation_type",
-          "ifabsent": "affine"
-        }
-      },
-      "attributes": {
-        "affine": {
-          "name": "affine",
-          "description": "The affine matrix",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "array": {
-            "exact_number_dimensions": 2,
-            "dimensions": [
-              {
-                "alias": "exact_card",
-                "exact_cardinality": 3
-              },
-              {
-                "alias": "exact_card",
-                "exact_cardinality": 3
-              }
-            ]
-          },
-          "alias": "affine",
-          "owner": "Affine",
-          "domain_of": [
-            "Affine"
-          ],
-          "range": "integer"
-        },
-        "transformation_type": {
-          "name": "transformation_type",
-          "description": "The type of transformation",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "ifabsent": "affine",
-          "alias": "transformation_type",
-          "owner": "Affine",
-          "domain_of": [
-            "CoordinateTransformation",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine",
-            "Sequence"
-          ],
-          "range": "TransformationType"
-        },
-        "name": {
-          "name": "name",
-          "description": "The name of the coordinate transformation",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "name",
-          "owner": "Affine",
-          "domain_of": [
-            "Average",
-            "Dataset",
-            "CoordinateSystem",
-            "CoordinateTransformation",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine",
-            "Sequence"
-          ],
-          "range": "string"
-        },
-        "input": {
-          "name": "input",
-          "description": "The source coordinate system name",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "input",
-          "owner": "Affine",
-          "domain_of": [
-            "CoordinateTransformation",
-            "ProjectionAlignment",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine"
-          ],
-          "range": "string"
-        },
-        "output": {
-          "name": "output",
-          "description": "The target coordinate system name",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "output",
-          "owner": "Affine",
-          "domain_of": [
-            "CoordinateTransformation",
-            "ProjectionAlignment",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "Sequence": {
-      "name": "Sequence",
-      "description": "A sequence of transformations",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "CoordinateTransformation",
-      "slots": [
-        "transformation_type"
-      ],
-      "slot_usage": {
-        "transformation_type": {
-          "name": "transformation_type",
-          "ifabsent": "sequence"
-        }
-      },
-      "attributes": {
-        "sequence": {
-          "name": "sequence",
-          "description": "The sequence of transformations",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "sequence",
-          "owner": "Sequence",
-          "domain_of": [
-            "Sequence",
-            "ProjectionAlignment"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        },
-        "transformation_type": {
-          "name": "transformation_type",
-          "description": "The type of transformation",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "ifabsent": "sequence",
-          "alias": "transformation_type",
-          "owner": "Sequence",
-          "domain_of": [
-            "CoordinateTransformation",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine",
-            "Sequence"
-          ],
-          "range": "TransformationType"
-        },
-        "name": {
-          "name": "name",
-          "description": "The name of the coordinate transformation",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "name",
-          "owner": "Sequence",
-          "domain_of": [
-            "Average",
-            "Dataset",
-            "CoordinateSystem",
-            "CoordinateTransformation",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine",
-            "Sequence"
-          ],
-          "range": "string"
-        },
-        "input": {
-          "name": "input",
-          "description": "The source coordinate system name",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "input",
-          "owner": "Sequence",
-          "domain_of": [
-            "CoordinateTransformation",
-            "ProjectionAlignment",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine"
-          ],
-          "range": "string"
-        },
-        "output": {
-          "name": "output",
-          "description": "The target coordinate system name",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "output",
-          "owner": "Sequence",
-          "domain_of": [
-            "CoordinateTransformation",
-            "ProjectionAlignment",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "CTFMetadata": {
-      "name": "CTFMetadata",
-      "description": "A set of CTF patameters for an image.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "slots": [
-        "defocus_u",
-        "defocus_v",
-        "defocus_angle"
-      ],
-      "attributes": {
-        "defocus_u": {
-          "name": "defocus_u",
-          "description": "Estimated defocus U for this image in Angstrom, underfocus positive.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "defocus_u",
-          "owner": "CTFMetadata",
-          "domain_of": [
-            "CTFMetadata"
-          ],
-          "range": "float"
-        },
-        "defocus_v": {
-          "name": "defocus_v",
-          "description": "Estimated defocus V for this image in Angstrom, underfocus positive.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "defocus_v",
-          "owner": "CTFMetadata",
-          "domain_of": [
-            "CTFMetadata"
-          ],
-          "range": "float"
-        },
-        "defocus_angle": {
-          "name": "defocus_angle",
-          "description": "Estimated angle of astigmatism.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "defocus_angle",
-          "owner": "CTFMetadata",
-          "domain_of": [
-            "CTFMetadata"
-          ],
-          "range": "float"
-        }
-      }
-    },
-    "AcquisitionMetadataMixin": {
-      "name": "AcquisitionMetadataMixin",
-      "description": "Metadata concerning the acquisition process.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "slots": [
-        "nominal_tilt_angle",
-        "accumulated_dose",
-        "ctf_metadata"
-      ],
-      "attributes": {
-        "nominal_tilt_angle": {
-          "name": "nominal_tilt_angle",
-          "description": "The tilt angle reported by the microscope",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "nominal_tilt_angle",
-          "owner": "AcquisitionMetadataMixin",
-          "domain_of": [
-            "AcquisitionMetadataMixin",
-            "MovieFrame",
-            "ProjectionImage"
-          ],
-          "range": "float"
-        },
-        "accumulated_dose": {
-          "name": "accumulated_dose",
-          "description": "The pre-exposure up to this image in e-/A^2",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "accumulated_dose",
-          "owner": "AcquisitionMetadataMixin",
-          "domain_of": [
-            "AcquisitionMetadataMixin",
-            "MovieFrame",
-            "ProjectionImage"
-          ],
-          "range": "float"
-        },
-        "ctf_metadata": {
-          "name": "ctf_metadata",
-          "description": "A set of CTF patameters for an image.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "ctf_metadata",
-          "owner": "AcquisitionMetadataMixin",
-          "domain_of": [
-            "AcquisitionMetadataMixin",
-            "MovieFrame",
-            "ProjectionImage"
-          ],
-          "range": "CTFMetadata"
-        }
-      }
-    },
-    "GainFile": {
-      "name": "GainFile",
-      "description": "A gain reference file.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "Image2D",
-      "slots": [
-        "path"
-      ],
-      "attributes": {
-        "path": {
-          "name": "path",
-          "description": "Path to a file.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "path",
-          "owner": "GainFile",
-          "domain_of": [
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "MovieStack",
-            "ProjectionImage",
-            "TiltSeries",
-            "Tomogram",
-            "ParticleMap",
-            "Annotation",
-            "SubProjectionImage",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "string"
-        },
-        "width": {
-          "name": "width",
-          "description": "The width of the image (x-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "width",
-          "owner": "GainFile",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "height": {
-          "name": "height",
-          "description": "The height of the image (y-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "height",
-          "owner": "GainFile",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "coordinate_systems": {
-          "name": "coordinate_systems",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_systems",
-          "owner": "GainFile",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateSystem",
-          "multivalued": true
-        },
-        "coordinate_transformations": {
-          "name": "coordinate_transformations",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_transformations",
-          "owner": "GainFile",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        }
-      }
-    },
-    "DefectFile": {
-      "name": "DefectFile",
-      "description": "A detector defect file.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "Image2D",
-      "slots": [
-        "path"
-      ],
-      "attributes": {
-        "path": {
-          "name": "path",
-          "description": "Path to a file.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "path",
-          "owner": "DefectFile",
-          "domain_of": [
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "MovieStack",
-            "ProjectionImage",
-            "TiltSeries",
-            "Tomogram",
-            "ParticleMap",
-            "Annotation",
-            "SubProjectionImage",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "string"
-        },
-        "width": {
-          "name": "width",
-          "description": "The width of the image (x-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "width",
-          "owner": "DefectFile",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "height": {
-          "name": "height",
-          "description": "The height of the image (y-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "height",
-          "owner": "DefectFile",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "coordinate_systems": {
-          "name": "coordinate_systems",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_systems",
-          "owner": "DefectFile",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateSystem",
-          "multivalued": true
-        },
-        "coordinate_transformations": {
-          "name": "coordinate_transformations",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_transformations",
-          "owner": "DefectFile",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        }
-      }
-    },
-    "MovieFrame": {
-      "name": "MovieFrame",
-      "description": "An individual movie frame",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "Image2D",
-      "mixins": [
-        "AcquisitionMetadataMixin"
-      ],
-      "slots": [
-        "path",
-        "section"
-      ],
-      "attributes": {
-        "path": {
-          "name": "path",
-          "description": "Path to a file.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "path",
-          "owner": "MovieFrame",
-          "domain_of": [
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "MovieStack",
-            "ProjectionImage",
-            "TiltSeries",
-            "Tomogram",
-            "ParticleMap",
-            "Annotation",
-            "SubProjectionImage",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "string"
-        },
-        "section": {
-          "name": "section",
-          "description": "0-based section index to the entity inside a stack.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "section",
-          "owner": "MovieFrame",
-          "domain_of": [
-            "MovieFrame",
-            "ProjectionImage"
-          ],
-          "range": "integer"
-        },
-        "nominal_tilt_angle": {
-          "name": "nominal_tilt_angle",
-          "description": "The tilt angle reported by the microscope",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "nominal_tilt_angle",
-          "owner": "MovieFrame",
-          "domain_of": [
-            "AcquisitionMetadataMixin",
-            "MovieFrame",
-            "ProjectionImage"
-          ],
-          "range": "float"
-        },
-        "accumulated_dose": {
-          "name": "accumulated_dose",
-          "description": "The pre-exposure up to this image in e-/A^2",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "accumulated_dose",
-          "owner": "MovieFrame",
-          "domain_of": [
-            "AcquisitionMetadataMixin",
-            "MovieFrame",
-            "ProjectionImage"
-          ],
-          "range": "float"
-        },
-        "ctf_metadata": {
-          "name": "ctf_metadata",
-          "description": "A set of CTF patameters for an image.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "ctf_metadata",
-          "owner": "MovieFrame",
-          "domain_of": [
-            "AcquisitionMetadataMixin",
-            "MovieFrame",
-            "ProjectionImage"
-          ],
-          "range": "CTFMetadata"
-        },
-        "width": {
-          "name": "width",
-          "description": "The width of the image (x-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "width",
-          "owner": "MovieFrame",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "height": {
-          "name": "height",
-          "description": "The height of the image (y-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "height",
-          "owner": "MovieFrame",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "coordinate_systems": {
-          "name": "coordinate_systems",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_systems",
-          "owner": "MovieFrame",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateSystem",
-          "multivalued": true
-        },
-        "coordinate_transformations": {
-          "name": "coordinate_transformations",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_transformations",
-          "owner": "MovieFrame",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        }
-      }
-    },
-    "MovieStack": {
-      "name": "MovieStack",
-      "description": "A stack of movie frames.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "slots": [
-        "path",
-        "images_movie"
-      ],
-      "attributes": {
-        "path": {
-          "name": "path",
-          "description": "Path to a file.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "path",
-          "owner": "MovieStack",
-          "domain_of": [
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "MovieStack",
-            "ProjectionImage",
-            "TiltSeries",
-            "Tomogram",
-            "ParticleMap",
-            "Annotation",
-            "SubProjectionImage",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "string"
-        },
-        "images_movie": {
-          "name": "images_movie",
-          "description": "The movie frames in the stack",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "images_movie",
-          "owner": "MovieStack",
-          "domain_of": [
-            "MovieStack"
-          ],
-          "range": "MovieFrame",
-          "multivalued": true
-        }
-      }
-    },
-    "ProjectionImage": {
-      "name": "ProjectionImage",
-      "description": "A projection image.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "Image2D",
-      "mixins": [
-        "AcquisitionMetadataMixin"
-      ],
-      "slots": [
-        "path",
-        "section"
-      ],
-      "attributes": {
-        "path": {
-          "name": "path",
-          "description": "Path to a file.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "path",
-          "owner": "ProjectionImage",
-          "domain_of": [
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "MovieStack",
-            "ProjectionImage",
-            "TiltSeries",
-            "Tomogram",
-            "ParticleMap",
-            "Annotation",
-            "SubProjectionImage",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "string"
-        },
-        "section": {
-          "name": "section",
-          "description": "0-based section index to the entity inside a stack.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "section",
-          "owner": "ProjectionImage",
-          "domain_of": [
-            "MovieFrame",
-            "ProjectionImage"
-          ],
-          "range": "integer"
-        },
-        "nominal_tilt_angle": {
-          "name": "nominal_tilt_angle",
-          "description": "The tilt angle reported by the microscope",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "nominal_tilt_angle",
-          "owner": "ProjectionImage",
-          "domain_of": [
-            "AcquisitionMetadataMixin",
-            "MovieFrame",
-            "ProjectionImage"
-          ],
-          "range": "float"
-        },
-        "accumulated_dose": {
-          "name": "accumulated_dose",
-          "description": "The pre-exposure up to this image in e-/A^2",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "accumulated_dose",
-          "owner": "ProjectionImage",
-          "domain_of": [
-            "AcquisitionMetadataMixin",
-            "MovieFrame",
-            "ProjectionImage"
-          ],
-          "range": "float"
-        },
-        "ctf_metadata": {
-          "name": "ctf_metadata",
-          "description": "A set of CTF patameters for an image.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "ctf_metadata",
-          "owner": "ProjectionImage",
-          "domain_of": [
-            "AcquisitionMetadataMixin",
-            "MovieFrame",
-            "ProjectionImage"
-          ],
-          "range": "CTFMetadata"
-        },
-        "width": {
-          "name": "width",
-          "description": "The width of the image (x-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "width",
-          "owner": "ProjectionImage",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "height": {
-          "name": "height",
-          "description": "The height of the image (y-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "height",
-          "owner": "ProjectionImage",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "coordinate_systems": {
-          "name": "coordinate_systems",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_systems",
-          "owner": "ProjectionImage",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateSystem",
-          "multivalued": true
-        },
-        "coordinate_transformations": {
-          "name": "coordinate_transformations",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_transformations",
-          "owner": "ProjectionImage",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        }
-      }
-    },
-    "MovieStackSeries": {
-      "name": "MovieStackSeries",
-      "description": "A group of movie stacks that belong to a single tilt series.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "attributes": {
-        "stacks": {
-          "name": "stacks",
-          "description": "The movie stacks.",
-          "from_schema": "https://w3id.org/cetmd/image_entities",
-          "alias": "stacks",
-          "owner": "MovieStackSeries",
-          "domain_of": [
-            "MovieStackSeries"
-          ],
-          "range": "MovieStack",
-          "multivalued": true
-        }
-      }
-    },
-    "TiltSeries": {
-      "name": "TiltSeries",
-      "description": "A stack of projection images.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "slots": [
-        "images_tilt",
-        "path"
-      ],
-      "attributes": {
-        "images_tilt": {
-          "name": "images_tilt",
-          "description": "The projections in the stack",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "images_tilt",
-          "owner": "TiltSeries",
-          "domain_of": [
-            "TiltSeries"
-          ],
-          "range": "ProjectionImage",
-          "multivalued": true
-        },
-        "path": {
-          "name": "path",
-          "description": "Path to a file.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "path",
-          "owner": "TiltSeries",
-          "domain_of": [
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "MovieStack",
-            "ProjectionImage",
-            "TiltSeries",
-            "Tomogram",
-            "ParticleMap",
-            "Annotation",
-            "SubProjectionImage",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "SubProjectionImage": {
-      "name": "SubProjectionImage",
-      "description": "A croppecd projection image.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "ProjectionImage",
-      "slots": [
-        "particle_index"
-      ],
-      "attributes": {
-        "particle_index": {
-          "name": "particle_index",
-          "description": "Index of a particle inside a tomogram.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "particle_index",
-          "owner": "SubProjectionImage",
-          "domain_of": [
-            "SubProjectionImage"
-          ],
-          "range": "integer"
-        },
-        "path": {
-          "name": "path",
-          "description": "Path to a file.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "path",
-          "owner": "SubProjectionImage",
-          "domain_of": [
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "MovieStack",
-            "ProjectionImage",
-            "TiltSeries",
-            "Tomogram",
-            "ParticleMap",
-            "Annotation",
-            "SubProjectionImage",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "string"
-        },
-        "section": {
-          "name": "section",
-          "description": "0-based section index to the entity inside a stack.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "section",
-          "owner": "SubProjectionImage",
-          "domain_of": [
-            "MovieFrame",
-            "ProjectionImage"
-          ],
-          "range": "integer"
-        },
-        "nominal_tilt_angle": {
-          "name": "nominal_tilt_angle",
-          "description": "The tilt angle reported by the microscope",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "nominal_tilt_angle",
-          "owner": "SubProjectionImage",
-          "domain_of": [
-            "AcquisitionMetadataMixin",
-            "MovieFrame",
-            "ProjectionImage"
-          ],
-          "range": "float"
-        },
-        "accumulated_dose": {
-          "name": "accumulated_dose",
-          "description": "The pre-exposure up to this image in e-/A^2",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "accumulated_dose",
-          "owner": "SubProjectionImage",
-          "domain_of": [
-            "AcquisitionMetadataMixin",
-            "MovieFrame",
-            "ProjectionImage"
-          ],
-          "range": "float"
-        },
-        "ctf_metadata": {
-          "name": "ctf_metadata",
-          "description": "A set of CTF patameters for an image.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "ctf_metadata",
-          "owner": "SubProjectionImage",
-          "domain_of": [
-            "AcquisitionMetadataMixin",
-            "MovieFrame",
-            "ProjectionImage"
-          ],
-          "range": "CTFMetadata"
-        },
-        "width": {
-          "name": "width",
-          "description": "The width of the image (x-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "width",
-          "owner": "SubProjectionImage",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "height": {
-          "name": "height",
-          "description": "The height of the image (y-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "height",
-          "owner": "SubProjectionImage",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "coordinate_systems": {
-          "name": "coordinate_systems",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_systems",
-          "owner": "SubProjectionImage",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateSystem",
-          "multivalued": true
-        },
-        "coordinate_transformations": {
-          "name": "coordinate_transformations",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_transformations",
-          "owner": "SubProjectionImage",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        }
-      }
-    },
-    "Tomogram": {
-      "name": "Tomogram",
-      "description": "A 3D tomogram.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "Image3D",
-      "slots": [
-        "path"
-      ],
-      "attributes": {
-        "path": {
-          "name": "path",
-          "description": "Path to a file.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "path",
-          "owner": "Tomogram",
-          "domain_of": [
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "MovieStack",
-            "ProjectionImage",
-            "TiltSeries",
-            "Tomogram",
-            "ParticleMap",
-            "Annotation",
-            "SubProjectionImage",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "string"
-        },
-        "width": {
-          "name": "width",
-          "description": "The width of the image (x-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "width",
-          "owner": "Tomogram",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "height": {
-          "name": "height",
-          "description": "The height of the image (y-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "height",
-          "owner": "Tomogram",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "depth": {
-          "name": "depth",
-          "description": "The depth of the image (z-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "depth",
-          "owner": "Tomogram",
-          "domain_of": [
-            "Image3D",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask3D"
-          ],
-          "range": "integer"
-        },
-        "coordinate_systems": {
-          "name": "coordinate_systems",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_systems",
-          "owner": "Tomogram",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateSystem",
-          "multivalued": true
-        },
-        "coordinate_transformations": {
-          "name": "coordinate_transformations",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_transformations",
-          "owner": "Tomogram",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        }
-      }
-    },
-    "ParticleMap": {
-      "name": "ParticleMap",
-      "description": "A 3D particle density map.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "Image3D",
-      "slots": [
-        "path"
-      ],
-      "attributes": {
-        "path": {
-          "name": "path",
-          "description": "Path to a file.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "path",
-          "owner": "ParticleMap",
-          "domain_of": [
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "MovieStack",
-            "ProjectionImage",
-            "TiltSeries",
-            "Tomogram",
-            "ParticleMap",
-            "Annotation",
-            "SubProjectionImage",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "string"
-        },
-        "width": {
-          "name": "width",
-          "description": "The width of the image (x-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "width",
-          "owner": "ParticleMap",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "height": {
-          "name": "height",
-          "description": "The height of the image (y-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "height",
-          "owner": "ParticleMap",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "depth": {
-          "name": "depth",
-          "description": "The depth of the image (z-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "depth",
-          "owner": "ParticleMap",
-          "domain_of": [
-            "Image3D",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask3D"
-          ],
-          "range": "integer"
-        },
-        "coordinate_systems": {
-          "name": "coordinate_systems",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_systems",
-          "owner": "ParticleMap",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateSystem",
-          "multivalued": true
-        },
-        "coordinate_transformations": {
-          "name": "coordinate_transformations",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_transformations",
-          "owner": "ParticleMap",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        }
-      }
-    },
-    "CoordMetaMixin": {
-      "name": "CoordMetaMixin",
-      "description": "Coordinate system mixins for annotations.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "slots": [
-        "coordinate_systems",
-        "coordinate_transformations"
-      ],
-      "attributes": {
-        "coordinate_systems": {
-          "name": "coordinate_systems",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_systems",
-          "owner": "CoordMetaMixin",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateSystem",
-          "multivalued": true
-        },
-        "coordinate_transformations": {
-          "name": "coordinate_transformations",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_transformations",
-          "owner": "CoordMetaMixin",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        }
-      }
-    },
-    "Annotation": {
-      "name": "Annotation",
-      "description": "A primitive annotation.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "slots": [
-        "path"
-      ],
-      "attributes": {
-        "path": {
-          "name": "path",
-          "description": "Path to a file.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "path",
-          "owner": "Annotation",
-          "domain_of": [
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "MovieStack",
-            "ProjectionImage",
-            "TiltSeries",
-            "Tomogram",
-            "ParticleMap",
-            "Annotation",
-            "SubProjectionImage",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "SegmentationMask2D": {
-      "name": "SegmentationMask2D",
-      "description": "An annotation image with categorical labels.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "Annotation",
-      "mixins": [
-        "Image2D"
-      ],
-      "attributes": {
-        "width": {
-          "name": "width",
-          "description": "The width of the image (x-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "width",
-          "owner": "SegmentationMask2D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "height": {
-          "name": "height",
-          "description": "The height of the image (y-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "height",
-          "owner": "SegmentationMask2D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "coordinate_systems": {
-          "name": "coordinate_systems",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_systems",
-          "owner": "SegmentationMask2D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateSystem",
-          "multivalued": true
-        },
-        "coordinate_transformations": {
-          "name": "coordinate_transformations",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_transformations",
-          "owner": "SegmentationMask2D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        },
-        "path": {
-          "name": "path",
-          "description": "Path to a file.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "path",
-          "owner": "SegmentationMask2D",
-          "domain_of": [
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "MovieStack",
-            "ProjectionImage",
-            "TiltSeries",
-            "Tomogram",
-            "ParticleMap",
-            "Annotation",
-            "SubProjectionImage",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "SegmentationMask3D": {
-      "name": "SegmentationMask3D",
-      "description": "An annotation volume with categorical labels.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "Annotation",
-      "mixins": [
-        "Image3D"
-      ],
-      "attributes": {
-        "width": {
-          "name": "width",
-          "description": "The width of the image (x-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "width",
-          "owner": "SegmentationMask3D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "height": {
-          "name": "height",
-          "description": "The height of the image (y-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "height",
-          "owner": "SegmentationMask3D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "depth": {
-          "name": "depth",
-          "description": "The depth of the image (z-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "depth",
-          "owner": "SegmentationMask3D",
-          "domain_of": [
-            "Image3D",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask3D"
-          ],
-          "range": "integer"
-        },
-        "coordinate_systems": {
-          "name": "coordinate_systems",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_systems",
-          "owner": "SegmentationMask3D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateSystem",
-          "multivalued": true
-        },
-        "coordinate_transformations": {
-          "name": "coordinate_transformations",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_transformations",
-          "owner": "SegmentationMask3D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        },
-        "path": {
-          "name": "path",
-          "description": "Path to a file.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "path",
-          "owner": "SegmentationMask3D",
-          "domain_of": [
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "MovieStack",
-            "ProjectionImage",
-            "TiltSeries",
-            "Tomogram",
-            "ParticleMap",
-            "Annotation",
-            "SubProjectionImage",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "ProbabilityMap2D": {
-      "name": "ProbabilityMap2D",
-      "description": "An annotation image with real-valued labels.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "Annotation",
-      "mixins": [
-        "Image2D"
-      ],
-      "attributes": {
-        "width": {
-          "name": "width",
-          "description": "The width of the image (x-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "width",
-          "owner": "ProbabilityMap2D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "height": {
-          "name": "height",
-          "description": "The height of the image (y-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "height",
-          "owner": "ProbabilityMap2D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "coordinate_systems": {
-          "name": "coordinate_systems",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_systems",
-          "owner": "ProbabilityMap2D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateSystem",
-          "multivalued": true
-        },
-        "coordinate_transformations": {
-          "name": "coordinate_transformations",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_transformations",
-          "owner": "ProbabilityMap2D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        },
-        "path": {
-          "name": "path",
-          "description": "Path to a file.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "path",
-          "owner": "ProbabilityMap2D",
-          "domain_of": [
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "MovieStack",
-            "ProjectionImage",
-            "TiltSeries",
-            "Tomogram",
-            "ParticleMap",
-            "Annotation",
-            "SubProjectionImage",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "ProbabilityMap3D": {
-      "name": "ProbabilityMap3D",
-      "description": "An annotation volume with real-valued labels.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "Annotation",
-      "mixins": [
-        "Image3D"
-      ],
-      "attributes": {
-        "width": {
-          "name": "width",
-          "description": "The width of the image (x-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "width",
-          "owner": "ProbabilityMap3D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "height": {
-          "name": "height",
-          "description": "The height of the image (y-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "height",
-          "owner": "ProbabilityMap3D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D"
-          ],
-          "range": "integer"
-        },
-        "depth": {
-          "name": "depth",
-          "description": "The depth of the image (z-axis) in pixels",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "depth",
-          "owner": "ProbabilityMap3D",
-          "domain_of": [
-            "Image3D",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask3D"
-          ],
-          "range": "integer"
-        },
-        "coordinate_systems": {
-          "name": "coordinate_systems",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_systems",
-          "owner": "ProbabilityMap3D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateSystem",
-          "multivalued": true
-        },
-        "coordinate_transformations": {
-          "name": "coordinate_transformations",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_transformations",
-          "owner": "ProbabilityMap3D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        },
-        "path": {
-          "name": "path",
-          "description": "Path to a file.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "path",
-          "owner": "ProbabilityMap3D",
-          "domain_of": [
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "MovieStack",
-            "ProjectionImage",
-            "TiltSeries",
-            "Tomogram",
-            "ParticleMap",
-            "Annotation",
-            "SubProjectionImage",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "PointSet2D": {
-      "name": "PointSet2D",
-      "description": "A set of 2D point annotations.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "Annotation",
-      "mixins": [
-        "CoordMetaMixin"
-      ],
-      "slots": [
-        "origin2D"
-      ],
-      "attributes": {
-        "origin2D": {
-          "name": "origin2D",
-          "description": "Location on a 2D image (Nx2).",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "array": {
-            "exact_number_dimensions": 2,
-            "dimensions": [
-              {
-                "alias": "N",
-                "minimum_cardinality": 1
-              },
-              {
-                "alias": "xy",
-                "exact_cardinality": 2
-              }
-            ]
-          },
-          "alias": "origin2D",
-          "owner": "PointSet2D",
-          "domain_of": [
-            "PointSet2D",
-            "PointVectorSet2D",
-            "PointMatrixSet2D"
-          ],
-          "range": "float"
-        },
-        "coordinate_systems": {
-          "name": "coordinate_systems",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_systems",
-          "owner": "PointSet2D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateSystem",
-          "multivalued": true
-        },
-        "coordinate_transformations": {
-          "name": "coordinate_transformations",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_transformations",
-          "owner": "PointSet2D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        },
-        "path": {
-          "name": "path",
-          "description": "Path to a file.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "path",
-          "owner": "PointSet2D",
-          "domain_of": [
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "MovieStack",
-            "ProjectionImage",
-            "TiltSeries",
-            "Tomogram",
-            "ParticleMap",
-            "Annotation",
-            "SubProjectionImage",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "PointSet3D": {
-      "name": "PointSet3D",
-      "description": "A set of 3D point annotations.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "Annotation",
-      "mixins": [
-        "CoordMetaMixin"
-      ],
-      "slots": [
-        "origin3D"
-      ],
-      "attributes": {
-        "origin3D": {
-          "name": "origin3D",
-          "description": "Location on a 3D image (Nx3).",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "array": {
-            "exact_number_dimensions": 2,
-            "dimensions": [
-              {
-                "alias": "N",
-                "minimum_cardinality": 1
-              },
-              {
-                "alias": "xyz",
-                "exact_cardinality": 3
-              }
-            ]
-          },
-          "alias": "origin3D",
-          "owner": "PointSet3D",
-          "domain_of": [
-            "PointSet3D",
-            "PointVectorSet3D",
-            "PointMatrixSet3D"
-          ],
-          "range": "float"
-        },
-        "coordinate_systems": {
-          "name": "coordinate_systems",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_systems",
-          "owner": "PointSet3D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateSystem",
-          "multivalued": true
-        },
-        "coordinate_transformations": {
-          "name": "coordinate_transformations",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_transformations",
-          "owner": "PointSet3D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        },
-        "path": {
-          "name": "path",
-          "description": "Path to a file.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "path",
-          "owner": "PointSet3D",
-          "domain_of": [
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "MovieStack",
-            "ProjectionImage",
-            "TiltSeries",
-            "Tomogram",
-            "ParticleMap",
-            "Annotation",
-            "SubProjectionImage",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "PointVectorSet2D": {
-      "name": "PointVectorSet2D",
-      "description": "A set of 2D points with an associated direction vector.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "Annotation",
-      "mixins": [
-        "CoordMetaMixin"
-      ],
-      "slots": [
-        "origin2D",
-        "vector2D"
-      ],
-      "attributes": {
-        "origin2D": {
-          "name": "origin2D",
-          "description": "Location on a 2D image (Nx2).",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "array": {
-            "exact_number_dimensions": 2,
-            "dimensions": [
-              {
-                "alias": "N",
-                "minimum_cardinality": 1
-              },
-              {
-                "alias": "xy",
-                "exact_cardinality": 2
-              }
-            ]
-          },
-          "alias": "origin2D",
-          "owner": "PointVectorSet2D",
-          "domain_of": [
-            "PointSet2D",
-            "PointVectorSet2D",
-            "PointMatrixSet2D"
-          ],
-          "range": "float"
-        },
-        "vector2D": {
-          "name": "vector2D",
-          "description": "Orientation vector associated with a point on a 2D image (Nx2).",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "array": {
-            "exact_number_dimensions": 2,
-            "dimensions": [
-              {
-                "alias": "N",
-                "minimum_cardinality": 1
-              },
-              {
-                "alias": "xy",
-                "exact_cardinality": 2
-              }
-            ]
-          },
-          "alias": "vector2D",
-          "owner": "PointVectorSet2D",
-          "domain_of": [
-            "PointVectorSet2D"
-          ],
-          "range": "float"
-        },
-        "coordinate_systems": {
-          "name": "coordinate_systems",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_systems",
-          "owner": "PointVectorSet2D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateSystem",
-          "multivalued": true
-        },
-        "coordinate_transformations": {
-          "name": "coordinate_transformations",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_transformations",
-          "owner": "PointVectorSet2D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        },
-        "path": {
-          "name": "path",
-          "description": "Path to a file.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "path",
-          "owner": "PointVectorSet2D",
-          "domain_of": [
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "MovieStack",
-            "ProjectionImage",
-            "TiltSeries",
-            "Tomogram",
-            "ParticleMap",
-            "Annotation",
-            "SubProjectionImage",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "PointVectorSet3D": {
-      "name": "PointVectorSet3D",
-      "description": "A set of 3D points with an associated direction vector.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "Annotation",
-      "mixins": [
-        "CoordMetaMixin"
-      ],
-      "slots": [
-        "origin3D",
-        "vector3D"
-      ],
-      "attributes": {
-        "origin3D": {
-          "name": "origin3D",
-          "description": "Location on a 3D image (Nx3).",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "array": {
-            "exact_number_dimensions": 2,
-            "dimensions": [
-              {
-                "alias": "N",
-                "minimum_cardinality": 1
-              },
-              {
-                "alias": "xyz",
-                "exact_cardinality": 3
-              }
-            ]
-          },
-          "alias": "origin3D",
-          "owner": "PointVectorSet3D",
-          "domain_of": [
-            "PointSet3D",
-            "PointVectorSet3D",
-            "PointMatrixSet3D"
-          ],
-          "range": "float"
-        },
-        "vector3D": {
-          "name": "vector3D",
-          "description": "Orientation vector associated with a point on a 3D image (Nx3).",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "array": {
-            "exact_number_dimensions": 2,
-            "dimensions": [
-              {
-                "alias": "N",
-                "minimum_cardinality": 1
-              },
-              {
-                "alias": "xyz",
-                "exact_cardinality": 3
-              }
-            ]
-          },
-          "alias": "vector3D",
-          "owner": "PointVectorSet3D",
-          "domain_of": [
-            "PointVectorSet3D"
-          ],
-          "range": "float"
-        },
-        "coordinate_systems": {
-          "name": "coordinate_systems",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_systems",
-          "owner": "PointVectorSet3D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateSystem",
-          "multivalued": true
-        },
-        "coordinate_transformations": {
-          "name": "coordinate_transformations",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_transformations",
-          "owner": "PointVectorSet3D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        },
-        "path": {
-          "name": "path",
-          "description": "Path to a file.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "path",
-          "owner": "PointVectorSet3D",
-          "domain_of": [
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "MovieStack",
-            "ProjectionImage",
-            "TiltSeries",
-            "Tomogram",
-            "ParticleMap",
-            "Annotation",
-            "SubProjectionImage",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "PointMatrixSet2D": {
-      "name": "PointMatrixSet2D",
-      "description": "A set of 2D points with an associated rotation matrix.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "Annotation",
-      "mixins": [
-        "CoordMetaMixin"
-      ],
-      "slots": [
-        "origin2D",
-        "matrix2D"
-      ],
-      "attributes": {
-        "origin2D": {
-          "name": "origin2D",
-          "description": "Location on a 2D image (Nx2).",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "array": {
-            "exact_number_dimensions": 2,
-            "dimensions": [
-              {
-                "alias": "N",
-                "minimum_cardinality": 1
-              },
-              {
-                "alias": "xy",
-                "exact_cardinality": 2
-              }
-            ]
-          },
-          "alias": "origin2D",
-          "owner": "PointMatrixSet2D",
-          "domain_of": [
-            "PointSet2D",
-            "PointVectorSet2D",
-            "PointMatrixSet2D"
-          ],
-          "range": "float"
-        },
-        "matrix2D": {
-          "name": "matrix2D",
-          "description": "Rotation matrix associated with a point on a 2D image (Nx2x2).",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "array": {
-            "exact_number_dimensions": 3,
-            "dimensions": [
-              {
-                "alias": "N",
-                "minimum_cardinality": 1
-              },
-              {
-                "alias": "xy",
-                "exact_cardinality": 2
-              },
-              {
-                "alias": "xy",
-                "exact_cardinality": 2
-              }
-            ]
-          },
-          "alias": "matrix2D",
-          "owner": "PointMatrixSet2D",
-          "domain_of": [
-            "PointMatrixSet2D"
-          ],
-          "range": "float"
-        },
-        "coordinate_systems": {
-          "name": "coordinate_systems",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_systems",
-          "owner": "PointMatrixSet2D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateSystem",
-          "multivalued": true
-        },
-        "coordinate_transformations": {
-          "name": "coordinate_transformations",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_transformations",
-          "owner": "PointMatrixSet2D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        },
-        "path": {
-          "name": "path",
-          "description": "Path to a file.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "path",
-          "owner": "PointMatrixSet2D",
-          "domain_of": [
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "MovieStack",
-            "ProjectionImage",
-            "TiltSeries",
-            "Tomogram",
-            "ParticleMap",
-            "Annotation",
-            "SubProjectionImage",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "PointMatrixSet3D": {
-      "name": "PointMatrixSet3D",
-      "description": "A set of 3D points with an associated rotation matrix.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "Annotation",
-      "mixins": [
-        "CoordMetaMixin"
-      ],
-      "slots": [
-        "origin3D",
-        "matrix3D"
-      ],
-      "attributes": {
-        "origin3D": {
-          "name": "origin3D",
-          "description": "Location on a 3D image (Nx3).",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "array": {
-            "exact_number_dimensions": 2,
-            "dimensions": [
-              {
-                "alias": "N",
-                "minimum_cardinality": 1
-              },
-              {
-                "alias": "xyz",
-                "exact_cardinality": 3
-              }
-            ]
-          },
-          "alias": "origin3D",
-          "owner": "PointMatrixSet3D",
-          "domain_of": [
-            "PointSet3D",
-            "PointVectorSet3D",
-            "PointMatrixSet3D"
-          ],
-          "range": "float"
-        },
-        "matrix3D": {
-          "name": "matrix3D",
-          "description": "Rotation matrix associated with a point on a 3D image (Nx3x3).",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "array": {
-            "exact_number_dimensions": 3,
-            "dimensions": [
-              {
-                "alias": "N",
-                "minimum_cardinality": 1
-              },
-              {
-                "alias": "xyz",
-                "exact_cardinality": 3
-              },
-              {
-                "alias": "xyz",
-                "exact_cardinality": 3
-              }
-            ]
-          },
-          "alias": "matrix3D",
-          "owner": "PointMatrixSet3D",
-          "domain_of": [
-            "PointMatrixSet3D"
-          ],
-          "range": "float"
-        },
-        "coordinate_systems": {
-          "name": "coordinate_systems",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_systems",
-          "owner": "PointMatrixSet3D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateSystem",
-          "multivalued": true
-        },
-        "coordinate_transformations": {
-          "name": "coordinate_transformations",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_transformations",
-          "owner": "PointMatrixSet3D",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        },
-        "path": {
-          "name": "path",
-          "description": "Path to a file.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "path",
-          "owner": "PointMatrixSet3D",
-          "domain_of": [
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "MovieStack",
-            "ProjectionImage",
-            "TiltSeries",
-            "Tomogram",
-            "ParticleMap",
-            "Annotation",
-            "SubProjectionImage",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "TriMesh": {
-      "name": "TriMesh",
-      "description": "A mesh annotation.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "Annotation",
-      "mixins": [
-        "CoordMetaMixin"
-      ],
-      "attributes": {
-        "coordinate_systems": {
-          "name": "coordinate_systems",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_systems",
-          "owner": "TriMesh",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateSystem",
-          "multivalued": true
-        },
-        "coordinate_transformations": {
-          "name": "coordinate_transformations",
-          "description": "Named coordinate systems for this entity",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "coordinate_transformations",
-          "owner": "TriMesh",
-          "domain_of": [
-            "Image2D",
-            "Image3D",
-            "CoordMetaMixin",
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "ProjectionImage",
-            "SubProjectionImage",
-            "Tomogram",
-            "ParticleMap",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true
-        },
-        "path": {
-          "name": "path",
-          "description": "Path to a file.",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "alias": "path",
-          "owner": "TriMesh",
-          "domain_of": [
-            "GainFile",
-            "DefectFile",
-            "MovieFrame",
-            "MovieStack",
-            "ProjectionImage",
-            "TiltSeries",
-            "Tomogram",
-            "ParticleMap",
-            "Annotation",
-            "SubProjectionImage",
-            "SegmentationMask2D",
-            "SegmentationMask3D",
-            "ProbabilityMap2D",
-            "ProbabilityMap3D",
-            "PointSet2D",
-            "PointSet3D",
-            "PointVectorSet2D",
-            "PointVectorSet3D",
-            "PointMatrixSet2D",
-            "PointMatrixSet3D"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "ProjectionAlignment": {
-      "name": "ProjectionAlignment",
-      "description": "The tomographic alignment for a single projection.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "is_a": "Sequence",
-      "attributes": {
-        "input": {
-          "name": "input",
-          "description": "The source coordinate system name",
-          "from_schema": "https://w3id.org/cetmd/alignment/",
-          "alias": "input",
-          "owner": "ProjectionAlignment",
-          "domain_of": [
-            "CoordinateTransformation",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine",
-            "Sequence",
-            "ProjectionAlignment"
-          ],
-          "range": "string"
-        },
-        "output": {
-          "name": "output",
-          "description": "The target coordinate system name",
-          "from_schema": "https://w3id.org/cetmd/alignment/",
-          "alias": "output",
-          "owner": "ProjectionAlignment",
-          "domain_of": [
-            "CoordinateTransformation",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine",
-            "Sequence",
-            "ProjectionAlignment"
-          ],
-          "range": "string"
-        },
-        "sequence": {
-          "name": "sequence",
-          "description": "The sequence of transformations",
-          "from_schema": "https://w3id.org/cetmd/alignment/",
-          "alias": "sequence",
-          "owner": "ProjectionAlignment",
-          "domain_of": [
-            "Sequence",
-            "ProjectionAlignment"
-          ],
-          "range": "CoordinateTransformation",
-          "multivalued": true,
-          "maximum_cardinality": 2,
-          "any_of": [
-            {
-              "range": "Affine"
-            },
-            {
-              "range": "Translation"
-            }
-          ]
-        },
-        "transformation_type": {
-          "name": "transformation_type",
-          "description": "The type of transformation",
-          "from_schema": "https://w3id.org/cetmd/entities",
-          "ifabsent": "sequence",
-          "alias": "transformation_type",
-          "owner": "ProjectionAlignment",
-          "domain_of": [
-            "CoordinateTransformation",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine",
-            "Sequence"
-          ],
-          "range": "TransformationType"
-        },
-        "name": {
-          "name": "name",
-          "description": "The name of the coordinate transformation",
-          "from_schema": "https://w3id.org/cetmd/coord_transforms",
-          "alias": "name",
-          "owner": "ProjectionAlignment",
-          "domain_of": [
-            "Average",
-            "Dataset",
-            "CoordinateSystem",
-            "CoordinateTransformation",
-            "Identity",
-            "MapAxis",
-            "Translation",
-            "Scale",
-            "Affine",
-            "Sequence"
-          ],
-          "range": "string"
-        }
-      }
-    },
-    "Alignment": {
-      "name": "Alignment",
-      "description": "The tomographic alignment for a tilt series.",
-      "from_schema": "https://w3id.org/cetmd/entities",
-      "attributes": {
-        "projection_alignments": {
-          "name": "projection_alignments",
-          "description": "alignment for a specific projection",
-          "from_schema": "https://w3id.org/cetmd/alignment/",
-          "alias": "projection_alignments",
-          "owner": "Alignment",
-          "domain_of": [
-            "Alignment"
-          ],
-          "range": "ProjectionAlignment",
-          "multivalued": true
-        }
-      }
-    }
-  },
-  "source_file": "schema/linkml/entities.yaml",
-  "@type": "SchemaDefinition"
-}
+name: entities
+description: Schema for cryoET geometry
+id: https://w3id.org/cetmd/entities
+version: 0.0.1
+prefixes:
+  linkml:
+    prefix_prefix: linkml
+    prefix_reference: https://w3id.org/linkml/
+  image_entities:
+    prefix_prefix: image_entities
+    prefix_reference: https://w3id.org/cetmd/image_entities/
+  entities:
+    prefix_prefix: entities
+    prefix_reference: https://w3id.org/cetmd/entities/
+  annotation:
+    prefix_prefix: annotation
+    prefix_reference: https://w3id.org/cetmd/annotation/
+  xsd:
+    prefix_prefix: xsd
+    prefix_reference: http://www.w3.org/2001/XMLSchema#
+  shex:
+    prefix_prefix: shex
+    prefix_reference: http://www.w3.org/ns/shex#
+  schema:
+    prefix_prefix: schema
+    prefix_reference: http://schema.org/
+  image:
+    prefix_prefix: image
+    prefix_reference: https://w3id.org/cetmd/image/
+  coordinate_systems:
+    prefix_prefix: coordinate_systems
+    prefix_reference: https://w3id.org/cetmd/coordinate_systems/
+  coord_transforms:
+    prefix_prefix: coord_transforms
+    prefix_reference: https://w3id.org/cetmd/coord_transforms/
+  annotations:
+    prefix_prefix: annotations
+    prefix_reference: https://w3id.org/cetmd/annotation/
+  alignment:
+    prefix_prefix: alignment
+    prefix_reference: https://w3id.org/cetmd/alignment/
+default_prefix: entities
+types:
+  string:
+    name: string
+    description: A character string
+    notes:
+    - In RDF serializations, a slot with range of string is treated as a literal or
+      type xsd:string.   If you are authoring schemas in LinkML YAML, the type is
+      referenced with the lower case "string".
+    from_schema: https://w3id.org/cetmd/entities
+    exact_mappings:
+    - schema:Text
+    base: str
+    uri: xsd:string
+  integer:
+    name: integer
+    description: An integer
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "integer".
+    from_schema: https://w3id.org/cetmd/entities
+    exact_mappings:
+    - schema:Integer
+    base: int
+    uri: xsd:integer
+  boolean:
+    name: boolean
+    description: A binary (true or false) value
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "boolean".
+    from_schema: https://w3id.org/cetmd/entities
+    exact_mappings:
+    - schema:Boolean
+    base: Bool
+    uri: xsd:boolean
+    repr: bool
+  float:
+    name: float
+    description: A real number that conforms to the xsd:float specification
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "float".
+    from_schema: https://w3id.org/cetmd/entities
+    exact_mappings:
+    - schema:Float
+    base: float
+    uri: xsd:float
+  double:
+    name: double
+    description: A real number that conforms to the xsd:double specification
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "double".
+    from_schema: https://w3id.org/cetmd/entities
+    close_mappings:
+    - schema:Float
+    base: float
+    uri: xsd:double
+  decimal:
+    name: decimal
+    description: A real number with arbitrary precision that conforms to the xsd:decimal
+      specification
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "decimal".
+    from_schema: https://w3id.org/cetmd/entities
+    broad_mappings:
+    - schema:Number
+    base: Decimal
+    uri: xsd:decimal
+  time:
+    name: time
+    description: A time object represents a (local) time of day, independent of any
+      particular day
+    notes:
+    - URI is dateTime because OWL reasoners do not work with straight date or time
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "time".
+    from_schema: https://w3id.org/cetmd/entities
+    exact_mappings:
+    - schema:Time
+    base: XSDTime
+    uri: xsd:time
+    repr: str
+  date:
+    name: date
+    description: a date (year, month and day) in an idealized calendar
+    notes:
+    - URI is dateTime because OWL reasoners don't work with straight date or time
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "date".
+    from_schema: https://w3id.org/cetmd/entities
+    exact_mappings:
+    - schema:Date
+    base: XSDDate
+    uri: xsd:date
+    repr: str
+  datetime:
+    name: datetime
+    description: The combination of a date and time
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "datetime".
+    from_schema: https://w3id.org/cetmd/entities
+    exact_mappings:
+    - schema:DateTime
+    base: XSDDateTime
+    uri: xsd:dateTime
+    repr: str
+  date_or_datetime:
+    name: date_or_datetime
+    description: Either a date or a datetime
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "date_or_datetime".
+    from_schema: https://w3id.org/cetmd/entities
+    base: str
+    uri: linkml:DateOrDatetime
+    repr: str
+  uriorcurie:
+    name: uriorcurie
+    description: a URI or a CURIE
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "uriorcurie".
+    from_schema: https://w3id.org/cetmd/entities
+    base: URIorCURIE
+    uri: xsd:anyURI
+    repr: str
+  curie:
+    name: curie
+    conforms_to: https://www.w3.org/TR/curie/
+    description: a compact URI
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "curie".
+    comments:
+    - in RDF serializations this MUST be expanded to a URI
+    - in non-RDF serializations MAY be serialized as the compact representation
+    from_schema: https://w3id.org/cetmd/entities
+    base: Curie
+    uri: xsd:string
+    repr: str
+  uri:
+    name: uri
+    conforms_to: https://www.ietf.org/rfc/rfc3987.txt
+    description: a complete URI
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "uri".
+    comments:
+    - in RDF serializations a slot with range of uri is treated as a literal or type
+      xsd:anyURI unless it is an identifier or a reference to an identifier, in which
+      case it is translated directly to a node
+    from_schema: https://w3id.org/cetmd/entities
+    close_mappings:
+    - schema:URL
+    base: URI
+    uri: xsd:anyURI
+    repr: str
+  ncname:
+    name: ncname
+    description: Prefix part of CURIE
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "ncname".
+    from_schema: https://w3id.org/cetmd/entities
+    base: NCName
+    uri: xsd:string
+    repr: str
+  objectidentifier:
+    name: objectidentifier
+    description: A URI or CURIE that represents an object in the model.
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "objectidentifier".
+    comments:
+    - Used for inheritance and type checking
+    from_schema: https://w3id.org/cetmd/entities
+    base: ElementIdentifier
+    uri: shex:iri
+    repr: str
+  nodeidentifier:
+    name: nodeidentifier
+    description: A URI, CURIE or BNODE that represents a node in a model.
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "nodeidentifier".
+    from_schema: https://w3id.org/cetmd/entities
+    base: NodeIdentifier
+    uri: shex:nonLiteral
+    repr: str
+  jsonpointer:
+    name: jsonpointer
+    conforms_to: https://datatracker.ietf.org/doc/html/rfc6901
+    description: A string encoding a JSON Pointer. The value of the string MUST conform
+      to JSON Point syntax and SHOULD dereference to a valid object within the current
+      instance document when encoded in tree form.
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "jsonpointer".
+    from_schema: https://w3id.org/cetmd/entities
+    base: str
+    uri: xsd:string
+    repr: str
+  jsonpath:
+    name: jsonpath
+    conforms_to: https://www.ietf.org/archive/id/draft-goessner-dispatch-jsonpath-00.html
+    description: A string encoding a JSON Path. The value of the string MUST conform
+      to JSON Point syntax and SHOULD dereference to zero or more valid objects within
+      the current instance document when encoded in tree form.
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "jsonpath".
+    from_schema: https://w3id.org/cetmd/entities
+    base: str
+    uri: xsd:string
+    repr: str
+  sparqlpath:
+    name: sparqlpath
+    conforms_to: https://www.w3.org/TR/sparql11-query/#propertypaths
+    description: A string encoding a SPARQL Property Path. The value of the string
+      MUST conform to SPARQL syntax and SHOULD dereference to zero or more valid objects
+      within the current instance document when encoded as RDF.
+    notes:
+    - If you are authoring schemas in LinkML YAML, the type is referenced with the
+      lower case "sparqlpath".
+    from_schema: https://w3id.org/cetmd/entities
+    base: str
+    uri: xsd:string
+    repr: str
+enums:
+  AxisType:
+    name: AxisType
+    description: The type of axis
+    from_schema: https://w3id.org/cetmd/entities
+    permissible_values:
+      space:
+        text: space
+        description: A spatial axis
+      array:
+        text: array
+        description: An array axis
+  TransformationType:
+    name: TransformationType
+    from_schema: https://w3id.org/cetmd/entities
+    permissible_values:
+      identity:
+        text: identity
+        description: The identity transformation.
+      map_axis:
+        text: map_axis
+        description: Axis permutation transformation
+      translation:
+        text: translation
+        description: A translation transformation.
+      scale:
+        text: scale
+        description: A scaling transformation.
+      affine:
+        text: affine
+        description: An affine transformation
+      sequence:
+        text: sequence
+        description: A sequence of transformations
+slots:
+  name:
+    name: name
+    description: The name of a given entry
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - Average
+    - Dataset
+    - CoordinateSystem
+    - CoordinateTransformation
+    range: string
+  annotations:
+    name: annotations
+    description: The annotations
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - Region
+    - Average
+    range: Annotation
+    multivalued: true
+  width:
+    name: width
+    description: The width of the image (x-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - Image2D
+    - Image3D
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - ProjectionImage
+    - SubProjectionImage
+    - Tomogram
+    - ParticleMap
+    - SegmentationMask2D
+    - SegmentationMask3D
+    - ProbabilityMap2D
+    range: integer
+  height:
+    name: height
+    description: The height of the image (y-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - Image2D
+    - Image3D
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - ProjectionImage
+    - SubProjectionImage
+    - Tomogram
+    - ParticleMap
+    - SegmentationMask2D
+    - SegmentationMask3D
+    - ProbabilityMap2D
+    range: integer
+  depth:
+    name: depth
+    description: The depth of the image (z-axis) in pixels
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - Image3D
+    - Tomogram
+    - ParticleMap
+    - SegmentationMask3D
+    range: integer
+  coordinate_systems:
+    name: coordinate_systems
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - ProjectionImage
+    - SubProjectionImage
+    - Tomogram
+    - ParticleMap
+    - SegmentationMask2D
+    - SegmentationMask3D
+    - ProbabilityMap2D
+    - ProbabilityMap3D
+    - PointSet2D
+    - PointSet3D
+    - PointVectorSet2D
+    - PointVectorSet3D
+    - PointMatrixSet2D
+    - PointMatrixSet3D
+    range: CoordinateSystem
+    multivalued: true
+  coordinate_transformations:
+    name: coordinate_transformations
+    description: Named coordinate systems for this entity
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - Image2D
+    - Image3D
+    - CoordMetaMixin
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - ProjectionImage
+    - SubProjectionImage
+    - Tomogram
+    - ParticleMap
+    - SegmentationMask2D
+    - SegmentationMask3D
+    - ProbabilityMap2D
+    - ProbabilityMap3D
+    - PointSet2D
+    - PointSet3D
+    - PointVectorSet2D
+    - PointVectorSet3D
+    - PointMatrixSet2D
+    - PointMatrixSet3D
+    range: CoordinateTransformation
+    multivalued: true
+  images2D:
+    name: images2D
+    description: The images in the stack
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - ImageStack2D
+    range: Image2D
+    multivalued: true
+  images3D:
+    name: images3D
+    description: The images in the stack
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - ImageStack3D
+    range: Image3D
+    multivalued: true
+  axis_name:
+    name: axis_name
+    description: The name of the axis
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - Axis
+    range: string
+  axis_unit:
+    name: axis_unit
+    description: The unit of the axis
+    from_schema: https://w3id.org/cetmd/entities
+    ifabsent: angstrom
+    domain_of:
+    - Axis
+    range: string
+  axis_type:
+    name: axis_type
+    description: The type of axis
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - Axis
+    range: AxisType
+  transformation_type:
+    name: transformation_type
+    description: The type of transformation
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - CoordinateTransformation
+    - Identity
+    - MapAxis
+    - Translation
+    - Scale
+    - Affine
+    - Sequence
+    range: TransformationType
+  path:
+    name: path
+    description: Path to a file.
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - GainFile
+    - DefectFile
+    - MovieFrame
+    - MovieStack
+    - ProjectionImage
+    - TiltSeries
+    - Tomogram
+    - ParticleMap
+    - Annotation
+    - SubProjectionImage
+    - SegmentationMask2D
+    - SegmentationMask3D
+    - ProbabilityMap2D
+    - ProbabilityMap3D
+    - PointSet2D
+    - PointSet3D
+    - PointVectorSet2D
+    - PointVectorSet3D
+    - PointMatrixSet2D
+    - PointMatrixSet3D
+    range: string
+  section:
+    name: section
+    description: 0-based section index to the entity inside a stack.
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - MovieFrame
+    - ProjectionImage
+    range: integer
+  nominal_tilt_angle:
+    name: nominal_tilt_angle
+    description: The tilt angle reported by the microscope
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - AcquisitionMetadataMixin
+    - MovieFrame
+    - ProjectionImage
+    range: float
+  accumulated_dose:
+    name: accumulated_dose
+    description: The pre-exposure up to this image in e-/A^2
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - AcquisitionMetadataMixin
+    - MovieFrame
+    - ProjectionImage
+    range: float
+  defocus_u:
+    name: defocus_u
+    description: Estimated defocus U for this image in Angstrom, underfocus positive.
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - CTFMetadata
+    range: float
+  defocus_v:
+    name: defocus_v
+    description: Estimated defocus V for this image in Angstrom, underfocus positive.
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - CTFMetadata
+    range: float
+  defocus_angle:
+    name: defocus_angle
+    description: Estimated angle of astigmatism.
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - CTFMetadata
+    range: float
+  particle_index:
+    name: particle_index
+    description: Index of a particle inside a tomogram.
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - SubProjectionImage
+    range: integer
+  ctf_metadata:
+    name: ctf_metadata
+    description: A set of CTF patameters for an image.
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - AcquisitionMetadataMixin
+    - MovieFrame
+    - ProjectionImage
+    range: CTFMetadata
+  images_movie:
+    name: images_movie
+    description: The movie frames in the stack
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - MovieStack
+    range: MovieFrame
+    multivalued: true
+  images_tilt:
+    name: images_tilt
+    description: The projections in the stack
+    from_schema: https://w3id.org/cetmd/entities
+    domain_of:
+    - TiltSeries
+    range: ProjectionImage
+    multivalued: true
+  origin2D:
+    name: origin2D
+    description: Location on a 2D image (Nx2).
+    from_schema: https://w3id.org/cetmd/entities
+    array:
+      exact_number_dimensions: 2
+      dimensions:
+      - alias: N
+        minimum_cardinality: 1
+      - alias: xy
+        exact_cardinality: 2
+    domain_of:
+    - PointSet2D
+    - PointVectorSet2D
+    - PointMatrixSet2D
+    range: float
+  translation2D:
+    name: translation2D
+    description: Offset from the origin of a point on a 2D image (Nx2).
+    from_schema: https://w3id.org/cetmd/entities
+    array:
+      exact_number_dimensions: 2
+      dimensions:
+      - alias: N
+        minimum_cardinality: 1
+      - alias: xy
+        exact_cardinality: 2
+    range: float
+  vector2D:
+    name: vector2D
+    description: Orientation vector associated with a point on a 2D image (Nx2).
+    from_schema: https://w3id.org/cetmd/entities
+    array:
+      exact_number_dimensions: 2
+      dimensions:
+      - alias: N
+        minimum_cardinality: 1
+      - alias: xy
+        exact_cardinality: 2
+    domain_of:
+    - PointVectorSet2D
+    range: float
+  matrix2D:
+    name: matrix2D
+    description: Rotation matrix associated with a point on a 2D image (Nx2x2).
+    from_schema: https://w3id.org/cetmd/entities
+    array:
+      exact_number_dimensions: 3
+      dimensions:
+      - alias: N
+        minimum_cardinality: 1
+      - alias: xy
+        exact_cardinality: 2
+      - alias: xy
+        exact_cardinality: 2
+    domain_of:
+    - PointMatrixSet2D
+    range: float
+  origin3D:
+    name: origin3D
+    description: Location on a 3D image (Nx3).
+    from_schema: https://w3id.org/cetmd/entities
+    array:
+      exact_number_dimensions: 2
+      dimensions:
+      - alias: N
+        minimum_cardinality: 1
+      - alias: xyz
+        exact_cardinality: 3
+    domain_of:
+    - PointSet3D
+    - PointVectorSet3D
+    - PointMatrixSet3D
+    range: float
+  translation3D:
+    name: translation3D
+    description: Offset from the origin of a point on a 3D image (Nx3).
+    from_schema: https://w3id.org/cetmd/entities
+    array:
+      exact_number_dimensions: 2
+      dimensions:
+      - alias: N
+        minimum_cardinality: 1
+      - alias: xyz
+        exact_cardinality: 3
+    range: float
+  vector3D:
+    name: vector3D
+    description: Orientation vector associated with a point on a 3D image (Nx3).
+    from_schema: https://w3id.org/cetmd/entities
+    array:
+      exact_number_dimensions: 2
+      dimensions:
+      - alias: N
+        minimum_cardinality: 1
+      - alias: xyz
+        exact_cardinality: 3
+    domain_of:
+    - PointVectorSet3D
+    range: float
+  matrix3D:
+    name: matrix3D
+    description: Rotation matrix associated with a point on a 3D image (Nx3x3).
+    from_schema: https://w3id.org/cetmd/entities
+    array:
+      exact_number_dimensions: 3
+      dimensions:
+      - alias: N
+        minimum_cardinality: 1
+      - alias: xyz
+        exact_cardinality: 3
+      - alias: xyz
+        exact_cardinality: 3
+    domain_of:
+    - PointMatrixSet3D
+    range: float
+classes:
+  Region:
+    name: Region
+    description: Raw data (movie stacks) and derived data (tilt series, tomograms,
+      annotations) from a single region of a specimen.
+    from_schema: https://w3id.org/cetmd/entities
+    slots:
+    - annotations
+    attributes:
+      movie_stack_collections:
+        name: movie_stack_collections
+        description: The movie stack
+        from_schema: https://w3id.org/cetmd/entities
+        alias: movie_stack_collections
+        owner: Region
+        domain_of:
+        - Region
+        range: MovieStackCollection
+        multivalued: true
+      tilt_series:
+        name: tilt_series
+        description: The tilt series
+        from_schema: https://w3id.org/cetmd/entities
+        alias: tilt_series
+        owner: Region
+        domain_of:
+        - Region
+        range: TiltSeries
+        multivalued: true
+      alignments:
+        name: alignments
+        description: The alignments
+        from_schema: https://w3id.org/cetmd/entities
+        alias: alignments
+        owner: Region
+        domain_of:
+        - Region
+        range: Alignment
+        multivalued: true
+      tomograms:
+        name: tomograms
+        description: The tomograms
+        from_schema: https://w3id.org/cetmd/entities
+        alias: tomograms
+        owner: Region
+        domain_of:
+        - Region
+        range: Tomogram
+        multivalued: true
+      annotations:
+        name: annotations
+        description: The annotations
+        from_schema: https://w3id.org/cetmd/entities
+        alias: annotations
+        owner: Region
+        domain_of:
+        - Region
+        - Average
+        range: Annotation
+        multivalued: true
+  Average:
+    name: Average
+    description: A particle averaging experiment.
+    from_schema: https://w3id.org/cetmd/entities
+    slots:
+    - name
+    - annotations
+    attributes:
+      particle_maps:
+        name: particle_maps
+        description: The particle maps
+        from_schema: https://w3id.org/cetmd/entities
+        alias: particle_maps
+        owner: Average
+        domain_of:
+        - Average
+        range: ParticleMap
+        multivalued: true
+      name:
+        name: name
+        description: The name of a given entry
+        from_schema: https://w3id.org/cetmd/entities
+        alias: name
+        owner: Average
+        domain_of:
+        - Average
+        - Dataset
+        - CoordinateSystem
+        - CoordinateTransformation
+        range: string
+      annotations:
+        name: annotations
+        description: The annotations
+        from_schema: https://w3id.org/cetmd/entities
+        alias: annotations
+        owner: Average
+        domain_of:
+        - Region
+        - Average
+        range: Annotation
+        multivalued: true
+  MovieStackCollection:
+    name: MovieStackCollection
+    description: A collection of movie stacks using the same gain and defect files.
+    from_schema: https://w3id.org/cetmd/entities
+    attributes:
+      movie_stacks:
+        name: movie_stacks
+        description: The movie stacks in the collection
+        from_schema: https://w3id.org/cetmd/entities
+        alias: movie_stacks
+        owner: MovieStackCollection
+        domain_of:
+        - MovieStackCollection
+        range: MovieStackSeries
+        multivalued: true
+      gain_file:
+        name: gain_file
+        description: The gain file for the movie stacks
+        from_schema: https://w3id.org/cetmd/entities
+        alias: gain_file
+        owner: MovieStackCollection
+        domain_of:
+        - MovieStackCollection
+        range: GainFile
+      defect_file:
+        name: defect_file
+        description: The defect file for the movie stacks
+        from_schema: https://w3id.org/cetmd/entities
+        alias: defect_file
+        owner: MovieStackCollection
+        domain_of:
+        - MovieStackCollection
+        range: DefectFile
+  Dataset:
+    name: Dataset
+    description: A dataset
+    from_schema: https://w3id.org/cetmd/entities
+    slots:
+    - name
+    attributes:
+      regions:
+        name: regions
+        description: The regions in the dataset
+        from_schema: https://w3id.org/cetmd/entities
+        alias: regions
+        owner: Dataset
+        domain_of:
+        - Dataset
+        range: Region
+        multivalued: true
+      averages:
+        name: averages
+        description: The averages in the dataset
+        from_schema: https://w3id.org/cetmd/entities
+        alias: averages
+        owner: Dataset
+        domain_of:
+        - Dataset
+        range: Average
+        multivalued: true
+      name:
+        name: name
+        description: The name of a given entry
+        from_schema: https://w3id.org/cetmd/entities
+        alias: name
+        owner: Dataset
+        domain_of:
+        - Average
+        - Dataset
+        - CoordinateSystem
+        - CoordinateTransformation
+        range: string
+  Image2D:
+    name: Image2D
+    description: A 2D image.
+    from_schema: https://w3id.org/cetmd/entities
+    slots:
+    - width
+    - height
+    - coordinate_systems
+    - coordinate_transformations
+    attributes:
+      width:
+        name: width
+        description: The width of the image (x-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: width
+        owner: Image2D
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      height:
+        name: height
+        description: The height of the image (y-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: height
+        owner: Image2D
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      coordinate_systems:
+        name: coordinate_systems
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_systems
+        owner: Image2D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateSystem
+        multivalued: true
+      coordinate_transformations:
+        name: coordinate_transformations
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_transformations
+        owner: Image2D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateTransformation
+        multivalued: true
+  Image3D:
+    name: Image3D
+    description: A 3D image.
+    from_schema: https://w3id.org/cetmd/entities
+    slots:
+    - width
+    - height
+    - depth
+    - coordinate_systems
+    - coordinate_transformations
+    attributes:
+      width:
+        name: width
+        description: The width of the image (x-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: width
+        owner: Image3D
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      height:
+        name: height
+        description: The height of the image (y-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: height
+        owner: Image3D
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      depth:
+        name: depth
+        description: The depth of the image (z-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: depth
+        owner: Image3D
+        domain_of:
+        - Image3D
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask3D
+        range: integer
+      coordinate_systems:
+        name: coordinate_systems
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_systems
+        owner: Image3D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateSystem
+        multivalued: true
+      coordinate_transformations:
+        name: coordinate_transformations
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_transformations
+        owner: Image3D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateTransformation
+        multivalued: true
+  ImageStack2D:
+    name: ImageStack2D
+    description: A stack of 2D images.
+    from_schema: https://w3id.org/cetmd/entities
+    slots:
+    - images2D
+    attributes:
+      images2D:
+        name: images2D
+        description: The images in the stack
+        from_schema: https://w3id.org/cetmd/entities
+        alias: images2D
+        owner: ImageStack2D
+        domain_of:
+        - ImageStack2D
+        range: Image2D
+        multivalued: true
+  ImageStack3D:
+    name: ImageStack3D
+    description: A stack of 3D images.
+    from_schema: https://w3id.org/cetmd/entities
+    slots:
+    - images3D
+    attributes:
+      images3D:
+        name: images3D
+        description: The images in the stack
+        from_schema: https://w3id.org/cetmd/entities
+        alias: images3D
+        owner: ImageStack3D
+        domain_of:
+        - ImageStack3D
+        range: Image3D
+        multivalued: true
+  Axis:
+    name: Axis
+    description: An axis in a coordinate system
+    from_schema: https://w3id.org/cetmd/entities
+    slots:
+    - axis_name
+    - axis_unit
+    - axis_type
+    attributes:
+      axis_name:
+        name: axis_name
+        description: The name of the axis
+        from_schema: https://w3id.org/cetmd/entities
+        alias: axis_name
+        owner: Axis
+        domain_of:
+        - Axis
+        range: string
+      axis_unit:
+        name: axis_unit
+        description: The unit of the axis
+        from_schema: https://w3id.org/cetmd/entities
+        ifabsent: angstrom
+        alias: axis_unit
+        owner: Axis
+        domain_of:
+        - Axis
+        range: string
+      axis_type:
+        name: axis_type
+        description: The type of axis
+        from_schema: https://w3id.org/cetmd/entities
+        alias: axis_type
+        owner: Axis
+        domain_of:
+        - Axis
+        range: AxisType
+  CoordinateSystem:
+    name: CoordinateSystem
+    description: A coordinate system
+    from_schema: https://w3id.org/cetmd/entities
+    attributes:
+      name:
+        name: name
+        description: The name of the coordinate system
+        from_schema: https://w3id.org/cetmd/coordinate_systems
+        alias: name
+        owner: CoordinateSystem
+        domain_of:
+        - Average
+        - Dataset
+        - CoordinateSystem
+        - CoordinateTransformation
+        range: string
+        required: true
+      axes:
+        name: axes
+        description: The axes of the coordinate system
+        from_schema: https://w3id.org/cetmd/coordinate_systems
+        alias: axes
+        owner: CoordinateSystem
+        domain_of:
+        - CoordinateSystem
+        range: Axis
+        required: true
+        multivalued: true
+  CoordinateTransformation:
+    name: CoordinateTransformation
+    description: A coordinate transformation
+    from_schema: https://w3id.org/cetmd/entities
+    slots:
+    - transformation_type
+    attributes:
+      name:
+        name: name
+        description: The name of the coordinate transformation
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: name
+        owner: CoordinateTransformation
+        domain_of:
+        - Average
+        - Dataset
+        - CoordinateSystem
+        - CoordinateTransformation
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        - Sequence
+        range: string
+      input:
+        name: input
+        description: The source coordinate system name
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: input
+        owner: CoordinateTransformation
+        domain_of:
+        - CoordinateTransformation
+        - ProjectionAlignment
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        range: string
+      output:
+        name: output
+        description: The target coordinate system name
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: output
+        owner: CoordinateTransformation
+        domain_of:
+        - CoordinateTransformation
+        - ProjectionAlignment
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        range: string
+      transformation_type:
+        name: transformation_type
+        description: The type of transformation
+        from_schema: https://w3id.org/cetmd/entities
+        alias: transformation_type
+        owner: CoordinateTransformation
+        domain_of:
+        - CoordinateTransformation
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        - Sequence
+        range: TransformationType
+  Identity:
+    name: Identity
+    description: The identity transformation
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: CoordinateTransformation
+    slots:
+    - transformation_type
+    slot_usage:
+      transformation_type:
+        name: transformation_type
+        ifabsent: identity
+    attributes:
+      transformation_type:
+        name: transformation_type
+        description: The type of transformation
+        from_schema: https://w3id.org/cetmd/entities
+        ifabsent: identity
+        alias: transformation_type
+        owner: Identity
+        domain_of:
+        - CoordinateTransformation
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        - Sequence
+        range: TransformationType
+      name:
+        name: name
+        description: The name of the coordinate transformation
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: name
+        owner: Identity
+        domain_of:
+        - Average
+        - Dataset
+        - CoordinateSystem
+        - CoordinateTransformation
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        - Sequence
+        range: string
+      input:
+        name: input
+        description: The source coordinate system name
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: input
+        owner: Identity
+        domain_of:
+        - CoordinateTransformation
+        - ProjectionAlignment
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        range: string
+      output:
+        name: output
+        description: The target coordinate system name
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: output
+        owner: Identity
+        domain_of:
+        - CoordinateTransformation
+        - ProjectionAlignment
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        range: string
+  AxisNameMapping:
+    name: AxisNameMapping
+    description: Axis name to Axis name mapping
+    from_schema: https://w3id.org/cetmd/entities
+    attributes:
+      axis1_name:
+        name: axis1_name
+        description: The type of transformation
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: axis1_name
+        owner: AxisNameMapping
+        domain_of:
+        - AxisNameMapping
+        range: string
+      axis2_name:
+        name: axis2_name
+        description: The mapping of the axis names
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: axis2_name
+        owner: AxisNameMapping
+        domain_of:
+        - AxisNameMapping
+        range: string
+  MapAxis:
+    name: MapAxis
+    description: Axis permutation transformation
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: CoordinateTransformation
+    slots:
+    - transformation_type
+    slot_usage:
+      transformation_type:
+        name: transformation_type
+        ifabsent: map_axis
+    attributes:
+      map_axis:
+        name: map_axis
+        description: The permutation of the axes
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: map_axis
+        owner: MapAxis
+        domain_of:
+        - MapAxis
+        range: AxisNameMapping
+        multivalued: true
+        inlined: true
+      transformation_type:
+        name: transformation_type
+        description: The type of transformation
+        from_schema: https://w3id.org/cetmd/entities
+        ifabsent: map_axis
+        alias: transformation_type
+        owner: MapAxis
+        domain_of:
+        - CoordinateTransformation
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        - Sequence
+        range: TransformationType
+      name:
+        name: name
+        description: The name of the coordinate transformation
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: name
+        owner: MapAxis
+        domain_of:
+        - Average
+        - Dataset
+        - CoordinateSystem
+        - CoordinateTransformation
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        - Sequence
+        range: string
+      input:
+        name: input
+        description: The source coordinate system name
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: input
+        owner: MapAxis
+        domain_of:
+        - CoordinateTransformation
+        - ProjectionAlignment
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        range: string
+      output:
+        name: output
+        description: The target coordinate system name
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: output
+        owner: MapAxis
+        domain_of:
+        - CoordinateTransformation
+        - ProjectionAlignment
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        range: string
+  Translation:
+    name: Translation
+    description: A translation transformation
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: CoordinateTransformation
+    slots:
+    - transformation_type
+    slot_usage:
+      transformation_type:
+        name: transformation_type
+        ifabsent: translation
+    attributes:
+      translation:
+        name: translation
+        description: The translation vector
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: translation
+        owner: Translation
+        domain_of:
+        - Translation
+        range: float
+        multivalued: true
+      transformation_type:
+        name: transformation_type
+        description: The type of transformation
+        from_schema: https://w3id.org/cetmd/entities
+        ifabsent: translation
+        alias: transformation_type
+        owner: Translation
+        domain_of:
+        - CoordinateTransformation
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        - Sequence
+        range: TransformationType
+      name:
+        name: name
+        description: The name of the coordinate transformation
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: name
+        owner: Translation
+        domain_of:
+        - Average
+        - Dataset
+        - CoordinateSystem
+        - CoordinateTransformation
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        - Sequence
+        range: string
+      input:
+        name: input
+        description: The source coordinate system name
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: input
+        owner: Translation
+        domain_of:
+        - CoordinateTransformation
+        - ProjectionAlignment
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        range: string
+      output:
+        name: output
+        description: The target coordinate system name
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: output
+        owner: Translation
+        domain_of:
+        - CoordinateTransformation
+        - ProjectionAlignment
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        range: string
+  Scale:
+    name: Scale
+    description: A scaling transformation
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: CoordinateTransformation
+    slots:
+    - transformation_type
+    slot_usage:
+      transformation_type:
+        name: transformation_type
+        ifabsent: scale
+    attributes:
+      scale:
+        name: scale
+        description: The scaling vector
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: scale
+        owner: Scale
+        domain_of:
+        - Scale
+        range: float
+        multivalued: true
+      transformation_type:
+        name: transformation_type
+        description: The type of transformation
+        from_schema: https://w3id.org/cetmd/entities
+        ifabsent: scale
+        alias: transformation_type
+        owner: Scale
+        domain_of:
+        - CoordinateTransformation
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        - Sequence
+        range: TransformationType
+      name:
+        name: name
+        description: The name of the coordinate transformation
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: name
+        owner: Scale
+        domain_of:
+        - Average
+        - Dataset
+        - CoordinateSystem
+        - CoordinateTransformation
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        - Sequence
+        range: string
+      input:
+        name: input
+        description: The source coordinate system name
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: input
+        owner: Scale
+        domain_of:
+        - CoordinateTransformation
+        - ProjectionAlignment
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        range: string
+      output:
+        name: output
+        description: The target coordinate system name
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: output
+        owner: Scale
+        domain_of:
+        - CoordinateTransformation
+        - ProjectionAlignment
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        range: string
+  Affine:
+    name: Affine
+    description: An affine transformation
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: CoordinateTransformation
+    slots:
+    - transformation_type
+    slot_usage:
+      transformation_type:
+        name: transformation_type
+        ifabsent: affine
+    attributes:
+      affine:
+        name: affine
+        description: The affine matrix
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        array:
+          exact_number_dimensions: 2
+          dimensions:
+          - alias: exact_card
+            exact_cardinality: 3
+          - alias: exact_card
+            exact_cardinality: 3
+        alias: affine
+        owner: Affine
+        domain_of:
+        - Affine
+        range: integer
+      transformation_type:
+        name: transformation_type
+        description: The type of transformation
+        from_schema: https://w3id.org/cetmd/entities
+        ifabsent: affine
+        alias: transformation_type
+        owner: Affine
+        domain_of:
+        - CoordinateTransformation
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        - Sequence
+        range: TransformationType
+      name:
+        name: name
+        description: The name of the coordinate transformation
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: name
+        owner: Affine
+        domain_of:
+        - Average
+        - Dataset
+        - CoordinateSystem
+        - CoordinateTransformation
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        - Sequence
+        range: string
+      input:
+        name: input
+        description: The source coordinate system name
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: input
+        owner: Affine
+        domain_of:
+        - CoordinateTransformation
+        - ProjectionAlignment
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        range: string
+      output:
+        name: output
+        description: The target coordinate system name
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: output
+        owner: Affine
+        domain_of:
+        - CoordinateTransformation
+        - ProjectionAlignment
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        range: string
+  Sequence:
+    name: Sequence
+    description: A sequence of transformations
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: CoordinateTransformation
+    slots:
+    - transformation_type
+    slot_usage:
+      transformation_type:
+        name: transformation_type
+        ifabsent: sequence
+    attributes:
+      sequence:
+        name: sequence
+        description: The sequence of transformations
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: sequence
+        owner: Sequence
+        domain_of:
+        - Sequence
+        - ProjectionAlignment
+        range: CoordinateTransformation
+        multivalued: true
+      transformation_type:
+        name: transformation_type
+        description: The type of transformation
+        from_schema: https://w3id.org/cetmd/entities
+        ifabsent: sequence
+        alias: transformation_type
+        owner: Sequence
+        domain_of:
+        - CoordinateTransformation
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        - Sequence
+        range: TransformationType
+      name:
+        name: name
+        description: The name of the coordinate transformation
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: name
+        owner: Sequence
+        domain_of:
+        - Average
+        - Dataset
+        - CoordinateSystem
+        - CoordinateTransformation
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        - Sequence
+        range: string
+      input:
+        name: input
+        description: The source coordinate system name
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: input
+        owner: Sequence
+        domain_of:
+        - CoordinateTransformation
+        - ProjectionAlignment
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        range: string
+      output:
+        name: output
+        description: The target coordinate system name
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: output
+        owner: Sequence
+        domain_of:
+        - CoordinateTransformation
+        - ProjectionAlignment
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        range: string
+  CTFMetadata:
+    name: CTFMetadata
+    description: A set of CTF patameters for an image.
+    from_schema: https://w3id.org/cetmd/entities
+    slots:
+    - defocus_u
+    - defocus_v
+    - defocus_angle
+    attributes:
+      defocus_u:
+        name: defocus_u
+        description: Estimated defocus U for this image in Angstrom, underfocus positive.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: defocus_u
+        owner: CTFMetadata
+        domain_of:
+        - CTFMetadata
+        range: float
+      defocus_v:
+        name: defocus_v
+        description: Estimated defocus V for this image in Angstrom, underfocus positive.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: defocus_v
+        owner: CTFMetadata
+        domain_of:
+        - CTFMetadata
+        range: float
+      defocus_angle:
+        name: defocus_angle
+        description: Estimated angle of astigmatism.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: defocus_angle
+        owner: CTFMetadata
+        domain_of:
+        - CTFMetadata
+        range: float
+  AcquisitionMetadataMixin:
+    name: AcquisitionMetadataMixin
+    description: Metadata concerning the acquisition process.
+    from_schema: https://w3id.org/cetmd/entities
+    slots:
+    - nominal_tilt_angle
+    - accumulated_dose
+    - ctf_metadata
+    attributes:
+      nominal_tilt_angle:
+        name: nominal_tilt_angle
+        description: The tilt angle reported by the microscope
+        from_schema: https://w3id.org/cetmd/entities
+        alias: nominal_tilt_angle
+        owner: AcquisitionMetadataMixin
+        domain_of:
+        - AcquisitionMetadataMixin
+        - MovieFrame
+        - ProjectionImage
+        range: float
+      accumulated_dose:
+        name: accumulated_dose
+        description: The pre-exposure up to this image in e-/A^2
+        from_schema: https://w3id.org/cetmd/entities
+        alias: accumulated_dose
+        owner: AcquisitionMetadataMixin
+        domain_of:
+        - AcquisitionMetadataMixin
+        - MovieFrame
+        - ProjectionImage
+        range: float
+      ctf_metadata:
+        name: ctf_metadata
+        description: A set of CTF patameters for an image.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: ctf_metadata
+        owner: AcquisitionMetadataMixin
+        domain_of:
+        - AcquisitionMetadataMixin
+        - MovieFrame
+        - ProjectionImage
+        range: CTFMetadata
+  GainFile:
+    name: GainFile
+    description: A gain reference file.
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: Image2D
+    slots:
+    - path
+    attributes:
+      path:
+        name: path
+        description: Path to a file.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: path
+        owner: GainFile
+        domain_of:
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - MovieStack
+        - ProjectionImage
+        - TiltSeries
+        - Tomogram
+        - ParticleMap
+        - Annotation
+        - SubProjectionImage
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: string
+      width:
+        name: width
+        description: The width of the image (x-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: width
+        owner: GainFile
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      height:
+        name: height
+        description: The height of the image (y-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: height
+        owner: GainFile
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      coordinate_systems:
+        name: coordinate_systems
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_systems
+        owner: GainFile
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateSystem
+        multivalued: true
+      coordinate_transformations:
+        name: coordinate_transformations
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_transformations
+        owner: GainFile
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateTransformation
+        multivalued: true
+  DefectFile:
+    name: DefectFile
+    description: A detector defect file.
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: Image2D
+    slots:
+    - path
+    attributes:
+      path:
+        name: path
+        description: Path to a file.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: path
+        owner: DefectFile
+        domain_of:
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - MovieStack
+        - ProjectionImage
+        - TiltSeries
+        - Tomogram
+        - ParticleMap
+        - Annotation
+        - SubProjectionImage
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: string
+      width:
+        name: width
+        description: The width of the image (x-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: width
+        owner: DefectFile
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      height:
+        name: height
+        description: The height of the image (y-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: height
+        owner: DefectFile
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      coordinate_systems:
+        name: coordinate_systems
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_systems
+        owner: DefectFile
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateSystem
+        multivalued: true
+      coordinate_transformations:
+        name: coordinate_transformations
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_transformations
+        owner: DefectFile
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateTransformation
+        multivalued: true
+  MovieFrame:
+    name: MovieFrame
+    description: An individual movie frame
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: Image2D
+    mixins:
+    - AcquisitionMetadataMixin
+    slots:
+    - path
+    - section
+    attributes:
+      path:
+        name: path
+        description: Path to a file.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: path
+        owner: MovieFrame
+        domain_of:
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - MovieStack
+        - ProjectionImage
+        - TiltSeries
+        - Tomogram
+        - ParticleMap
+        - Annotation
+        - SubProjectionImage
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: string
+      section:
+        name: section
+        description: 0-based section index to the entity inside a stack.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: section
+        owner: MovieFrame
+        domain_of:
+        - MovieFrame
+        - ProjectionImage
+        range: integer
+      nominal_tilt_angle:
+        name: nominal_tilt_angle
+        description: The tilt angle reported by the microscope
+        from_schema: https://w3id.org/cetmd/entities
+        alias: nominal_tilt_angle
+        owner: MovieFrame
+        domain_of:
+        - AcquisitionMetadataMixin
+        - MovieFrame
+        - ProjectionImage
+        range: float
+      accumulated_dose:
+        name: accumulated_dose
+        description: The pre-exposure up to this image in e-/A^2
+        from_schema: https://w3id.org/cetmd/entities
+        alias: accumulated_dose
+        owner: MovieFrame
+        domain_of:
+        - AcquisitionMetadataMixin
+        - MovieFrame
+        - ProjectionImage
+        range: float
+      ctf_metadata:
+        name: ctf_metadata
+        description: A set of CTF patameters for an image.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: ctf_metadata
+        owner: MovieFrame
+        domain_of:
+        - AcquisitionMetadataMixin
+        - MovieFrame
+        - ProjectionImage
+        range: CTFMetadata
+      width:
+        name: width
+        description: The width of the image (x-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: width
+        owner: MovieFrame
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      height:
+        name: height
+        description: The height of the image (y-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: height
+        owner: MovieFrame
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      coordinate_systems:
+        name: coordinate_systems
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_systems
+        owner: MovieFrame
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateSystem
+        multivalued: true
+      coordinate_transformations:
+        name: coordinate_transformations
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_transformations
+        owner: MovieFrame
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateTransformation
+        multivalued: true
+  MovieStack:
+    name: MovieStack
+    description: A stack of movie frames.
+    from_schema: https://w3id.org/cetmd/entities
+    slots:
+    - path
+    - images_movie
+    attributes:
+      path:
+        name: path
+        description: Path to a file.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: path
+        owner: MovieStack
+        domain_of:
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - MovieStack
+        - ProjectionImage
+        - TiltSeries
+        - Tomogram
+        - ParticleMap
+        - Annotation
+        - SubProjectionImage
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: string
+      images_movie:
+        name: images_movie
+        description: The movie frames in the stack
+        from_schema: https://w3id.org/cetmd/entities
+        alias: images_movie
+        owner: MovieStack
+        domain_of:
+        - MovieStack
+        range: MovieFrame
+        multivalued: true
+  ProjectionImage:
+    name: ProjectionImage
+    description: A projection image.
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: Image2D
+    mixins:
+    - AcquisitionMetadataMixin
+    slots:
+    - path
+    - section
+    attributes:
+      path:
+        name: path
+        description: Path to a file.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: path
+        owner: ProjectionImage
+        domain_of:
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - MovieStack
+        - ProjectionImage
+        - TiltSeries
+        - Tomogram
+        - ParticleMap
+        - Annotation
+        - SubProjectionImage
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: string
+      section:
+        name: section
+        description: 0-based section index to the entity inside a stack.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: section
+        owner: ProjectionImage
+        domain_of:
+        - MovieFrame
+        - ProjectionImage
+        range: integer
+      nominal_tilt_angle:
+        name: nominal_tilt_angle
+        description: The tilt angle reported by the microscope
+        from_schema: https://w3id.org/cetmd/entities
+        alias: nominal_tilt_angle
+        owner: ProjectionImage
+        domain_of:
+        - AcquisitionMetadataMixin
+        - MovieFrame
+        - ProjectionImage
+        range: float
+      accumulated_dose:
+        name: accumulated_dose
+        description: The pre-exposure up to this image in e-/A^2
+        from_schema: https://w3id.org/cetmd/entities
+        alias: accumulated_dose
+        owner: ProjectionImage
+        domain_of:
+        - AcquisitionMetadataMixin
+        - MovieFrame
+        - ProjectionImage
+        range: float
+      ctf_metadata:
+        name: ctf_metadata
+        description: A set of CTF patameters for an image.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: ctf_metadata
+        owner: ProjectionImage
+        domain_of:
+        - AcquisitionMetadataMixin
+        - MovieFrame
+        - ProjectionImage
+        range: CTFMetadata
+      width:
+        name: width
+        description: The width of the image (x-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: width
+        owner: ProjectionImage
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      height:
+        name: height
+        description: The height of the image (y-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: height
+        owner: ProjectionImage
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      coordinate_systems:
+        name: coordinate_systems
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_systems
+        owner: ProjectionImage
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateSystem
+        multivalued: true
+      coordinate_transformations:
+        name: coordinate_transformations
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_transformations
+        owner: ProjectionImage
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateTransformation
+        multivalued: true
+  MovieStackSeries:
+    name: MovieStackSeries
+    description: A group of movie stacks that belong to a single tilt series.
+    from_schema: https://w3id.org/cetmd/entities
+    attributes:
+      stacks:
+        name: stacks
+        description: The movie stacks.
+        from_schema: https://w3id.org/cetmd/image_entities
+        alias: stacks
+        owner: MovieStackSeries
+        domain_of:
+        - MovieStackSeries
+        range: MovieStack
+        multivalued: true
+  TiltSeries:
+    name: TiltSeries
+    description: A stack of projection images.
+    from_schema: https://w3id.org/cetmd/entities
+    slots:
+    - images_tilt
+    - path
+    attributes:
+      images_tilt:
+        name: images_tilt
+        description: The projections in the stack
+        from_schema: https://w3id.org/cetmd/entities
+        alias: images_tilt
+        owner: TiltSeries
+        domain_of:
+        - TiltSeries
+        range: ProjectionImage
+        multivalued: true
+      path:
+        name: path
+        description: Path to a file.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: path
+        owner: TiltSeries
+        domain_of:
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - MovieStack
+        - ProjectionImage
+        - TiltSeries
+        - Tomogram
+        - ParticleMap
+        - Annotation
+        - SubProjectionImage
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: string
+  SubProjectionImage:
+    name: SubProjectionImage
+    description: A croppecd projection image.
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: ProjectionImage
+    slots:
+    - particle_index
+    attributes:
+      particle_index:
+        name: particle_index
+        description: Index of a particle inside a tomogram.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: particle_index
+        owner: SubProjectionImage
+        domain_of:
+        - SubProjectionImage
+        range: integer
+      path:
+        name: path
+        description: Path to a file.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: path
+        owner: SubProjectionImage
+        domain_of:
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - MovieStack
+        - ProjectionImage
+        - TiltSeries
+        - Tomogram
+        - ParticleMap
+        - Annotation
+        - SubProjectionImage
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: string
+      section:
+        name: section
+        description: 0-based section index to the entity inside a stack.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: section
+        owner: SubProjectionImage
+        domain_of:
+        - MovieFrame
+        - ProjectionImage
+        range: integer
+      nominal_tilt_angle:
+        name: nominal_tilt_angle
+        description: The tilt angle reported by the microscope
+        from_schema: https://w3id.org/cetmd/entities
+        alias: nominal_tilt_angle
+        owner: SubProjectionImage
+        domain_of:
+        - AcquisitionMetadataMixin
+        - MovieFrame
+        - ProjectionImage
+        range: float
+      accumulated_dose:
+        name: accumulated_dose
+        description: The pre-exposure up to this image in e-/A^2
+        from_schema: https://w3id.org/cetmd/entities
+        alias: accumulated_dose
+        owner: SubProjectionImage
+        domain_of:
+        - AcquisitionMetadataMixin
+        - MovieFrame
+        - ProjectionImage
+        range: float
+      ctf_metadata:
+        name: ctf_metadata
+        description: A set of CTF patameters for an image.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: ctf_metadata
+        owner: SubProjectionImage
+        domain_of:
+        - AcquisitionMetadataMixin
+        - MovieFrame
+        - ProjectionImage
+        range: CTFMetadata
+      width:
+        name: width
+        description: The width of the image (x-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: width
+        owner: SubProjectionImage
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      height:
+        name: height
+        description: The height of the image (y-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: height
+        owner: SubProjectionImage
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      coordinate_systems:
+        name: coordinate_systems
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_systems
+        owner: SubProjectionImage
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateSystem
+        multivalued: true
+      coordinate_transformations:
+        name: coordinate_transformations
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_transformations
+        owner: SubProjectionImage
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateTransformation
+        multivalued: true
+  Tomogram:
+    name: Tomogram
+    description: A 3D tomogram.
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: Image3D
+    slots:
+    - path
+    attributes:
+      path:
+        name: path
+        description: Path to a file.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: path
+        owner: Tomogram
+        domain_of:
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - MovieStack
+        - ProjectionImage
+        - TiltSeries
+        - Tomogram
+        - ParticleMap
+        - Annotation
+        - SubProjectionImage
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: string
+      width:
+        name: width
+        description: The width of the image (x-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: width
+        owner: Tomogram
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      height:
+        name: height
+        description: The height of the image (y-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: height
+        owner: Tomogram
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      depth:
+        name: depth
+        description: The depth of the image (z-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: depth
+        owner: Tomogram
+        domain_of:
+        - Image3D
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask3D
+        range: integer
+      coordinate_systems:
+        name: coordinate_systems
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_systems
+        owner: Tomogram
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateSystem
+        multivalued: true
+      coordinate_transformations:
+        name: coordinate_transformations
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_transformations
+        owner: Tomogram
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateTransformation
+        multivalued: true
+  ParticleMap:
+    name: ParticleMap
+    description: A 3D particle density map.
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: Image3D
+    slots:
+    - path
+    attributes:
+      path:
+        name: path
+        description: Path to a file.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: path
+        owner: ParticleMap
+        domain_of:
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - MovieStack
+        - ProjectionImage
+        - TiltSeries
+        - Tomogram
+        - ParticleMap
+        - Annotation
+        - SubProjectionImage
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: string
+      width:
+        name: width
+        description: The width of the image (x-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: width
+        owner: ParticleMap
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      height:
+        name: height
+        description: The height of the image (y-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: height
+        owner: ParticleMap
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      depth:
+        name: depth
+        description: The depth of the image (z-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: depth
+        owner: ParticleMap
+        domain_of:
+        - Image3D
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask3D
+        range: integer
+      coordinate_systems:
+        name: coordinate_systems
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_systems
+        owner: ParticleMap
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateSystem
+        multivalued: true
+      coordinate_transformations:
+        name: coordinate_transformations
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_transformations
+        owner: ParticleMap
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateTransformation
+        multivalued: true
+  CoordMetaMixin:
+    name: CoordMetaMixin
+    description: Coordinate system mixins for annotations.
+    from_schema: https://w3id.org/cetmd/entities
+    slots:
+    - coordinate_systems
+    - coordinate_transformations
+    attributes:
+      coordinate_systems:
+        name: coordinate_systems
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_systems
+        owner: CoordMetaMixin
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateSystem
+        multivalued: true
+      coordinate_transformations:
+        name: coordinate_transformations
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_transformations
+        owner: CoordMetaMixin
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateTransformation
+        multivalued: true
+  Annotation:
+    name: Annotation
+    description: A primitive annotation.
+    from_schema: https://w3id.org/cetmd/entities
+    slots:
+    - path
+    attributes:
+      path:
+        name: path
+        description: Path to a file.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: path
+        owner: Annotation
+        domain_of:
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - MovieStack
+        - ProjectionImage
+        - TiltSeries
+        - Tomogram
+        - ParticleMap
+        - Annotation
+        - SubProjectionImage
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: string
+  SegmentationMask2D:
+    name: SegmentationMask2D
+    description: An annotation image with categorical labels.
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: Annotation
+    mixins:
+    - Image2D
+    attributes:
+      width:
+        name: width
+        description: The width of the image (x-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: width
+        owner: SegmentationMask2D
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      height:
+        name: height
+        description: The height of the image (y-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: height
+        owner: SegmentationMask2D
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      coordinate_systems:
+        name: coordinate_systems
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_systems
+        owner: SegmentationMask2D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateSystem
+        multivalued: true
+      coordinate_transformations:
+        name: coordinate_transformations
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_transformations
+        owner: SegmentationMask2D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateTransformation
+        multivalued: true
+      path:
+        name: path
+        description: Path to a file.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: path
+        owner: SegmentationMask2D
+        domain_of:
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - MovieStack
+        - ProjectionImage
+        - TiltSeries
+        - Tomogram
+        - ParticleMap
+        - Annotation
+        - SubProjectionImage
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: string
+  SegmentationMask3D:
+    name: SegmentationMask3D
+    description: An annotation volume with categorical labels.
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: Annotation
+    mixins:
+    - Image3D
+    attributes:
+      width:
+        name: width
+        description: The width of the image (x-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: width
+        owner: SegmentationMask3D
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      height:
+        name: height
+        description: The height of the image (y-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: height
+        owner: SegmentationMask3D
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      depth:
+        name: depth
+        description: The depth of the image (z-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: depth
+        owner: SegmentationMask3D
+        domain_of:
+        - Image3D
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask3D
+        range: integer
+      coordinate_systems:
+        name: coordinate_systems
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_systems
+        owner: SegmentationMask3D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateSystem
+        multivalued: true
+      coordinate_transformations:
+        name: coordinate_transformations
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_transformations
+        owner: SegmentationMask3D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateTransformation
+        multivalued: true
+      path:
+        name: path
+        description: Path to a file.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: path
+        owner: SegmentationMask3D
+        domain_of:
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - MovieStack
+        - ProjectionImage
+        - TiltSeries
+        - Tomogram
+        - ParticleMap
+        - Annotation
+        - SubProjectionImage
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: string
+  ProbabilityMap2D:
+    name: ProbabilityMap2D
+    description: An annotation image with real-valued labels.
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: Annotation
+    mixins:
+    - Image2D
+    attributes:
+      width:
+        name: width
+        description: The width of the image (x-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: width
+        owner: ProbabilityMap2D
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      height:
+        name: height
+        description: The height of the image (y-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: height
+        owner: ProbabilityMap2D
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      coordinate_systems:
+        name: coordinate_systems
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_systems
+        owner: ProbabilityMap2D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateSystem
+        multivalued: true
+      coordinate_transformations:
+        name: coordinate_transformations
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_transformations
+        owner: ProbabilityMap2D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateTransformation
+        multivalued: true
+      path:
+        name: path
+        description: Path to a file.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: path
+        owner: ProbabilityMap2D
+        domain_of:
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - MovieStack
+        - ProjectionImage
+        - TiltSeries
+        - Tomogram
+        - ParticleMap
+        - Annotation
+        - SubProjectionImage
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: string
+  ProbabilityMap3D:
+    name: ProbabilityMap3D
+    description: An annotation volume with real-valued labels.
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: Annotation
+    mixins:
+    - Image3D
+    attributes:
+      width:
+        name: width
+        description: The width of the image (x-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: width
+        owner: ProbabilityMap3D
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      height:
+        name: height
+        description: The height of the image (y-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: height
+        owner: ProbabilityMap3D
+        domain_of:
+        - Image2D
+        - Image3D
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        range: integer
+      depth:
+        name: depth
+        description: The depth of the image (z-axis) in pixels
+        from_schema: https://w3id.org/cetmd/entities
+        alias: depth
+        owner: ProbabilityMap3D
+        domain_of:
+        - Image3D
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask3D
+        range: integer
+      coordinate_systems:
+        name: coordinate_systems
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_systems
+        owner: ProbabilityMap3D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateSystem
+        multivalued: true
+      coordinate_transformations:
+        name: coordinate_transformations
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_transformations
+        owner: ProbabilityMap3D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateTransformation
+        multivalued: true
+      path:
+        name: path
+        description: Path to a file.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: path
+        owner: ProbabilityMap3D
+        domain_of:
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - MovieStack
+        - ProjectionImage
+        - TiltSeries
+        - Tomogram
+        - ParticleMap
+        - Annotation
+        - SubProjectionImage
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: string
+  PointSet2D:
+    name: PointSet2D
+    description: A set of 2D point annotations.
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: Annotation
+    mixins:
+    - CoordMetaMixin
+    slots:
+    - origin2D
+    attributes:
+      origin2D:
+        name: origin2D
+        description: Location on a 2D image (Nx2).
+        from_schema: https://w3id.org/cetmd/entities
+        array:
+          exact_number_dimensions: 2
+          dimensions:
+          - alias: N
+            minimum_cardinality: 1
+          - alias: xy
+            exact_cardinality: 2
+        alias: origin2D
+        owner: PointSet2D
+        domain_of:
+        - PointSet2D
+        - PointVectorSet2D
+        - PointMatrixSet2D
+        range: float
+      coordinate_systems:
+        name: coordinate_systems
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_systems
+        owner: PointSet2D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateSystem
+        multivalued: true
+      coordinate_transformations:
+        name: coordinate_transformations
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_transformations
+        owner: PointSet2D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateTransformation
+        multivalued: true
+      path:
+        name: path
+        description: Path to a file.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: path
+        owner: PointSet2D
+        domain_of:
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - MovieStack
+        - ProjectionImage
+        - TiltSeries
+        - Tomogram
+        - ParticleMap
+        - Annotation
+        - SubProjectionImage
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: string
+  PointSet3D:
+    name: PointSet3D
+    description: A set of 3D point annotations.
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: Annotation
+    mixins:
+    - CoordMetaMixin
+    slots:
+    - origin3D
+    attributes:
+      origin3D:
+        name: origin3D
+        description: Location on a 3D image (Nx3).
+        from_schema: https://w3id.org/cetmd/entities
+        array:
+          exact_number_dimensions: 2
+          dimensions:
+          - alias: N
+            minimum_cardinality: 1
+          - alias: xyz
+            exact_cardinality: 3
+        alias: origin3D
+        owner: PointSet3D
+        domain_of:
+        - PointSet3D
+        - PointVectorSet3D
+        - PointMatrixSet3D
+        range: float
+      coordinate_systems:
+        name: coordinate_systems
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_systems
+        owner: PointSet3D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateSystem
+        multivalued: true
+      coordinate_transformations:
+        name: coordinate_transformations
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_transformations
+        owner: PointSet3D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateTransformation
+        multivalued: true
+      path:
+        name: path
+        description: Path to a file.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: path
+        owner: PointSet3D
+        domain_of:
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - MovieStack
+        - ProjectionImage
+        - TiltSeries
+        - Tomogram
+        - ParticleMap
+        - Annotation
+        - SubProjectionImage
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: string
+  PointVectorSet2D:
+    name: PointVectorSet2D
+    description: A set of 2D points with an associated direction vector.
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: Annotation
+    mixins:
+    - CoordMetaMixin
+    slots:
+    - origin2D
+    - vector2D
+    attributes:
+      origin2D:
+        name: origin2D
+        description: Location on a 2D image (Nx2).
+        from_schema: https://w3id.org/cetmd/entities
+        array:
+          exact_number_dimensions: 2
+          dimensions:
+          - alias: N
+            minimum_cardinality: 1
+          - alias: xy
+            exact_cardinality: 2
+        alias: origin2D
+        owner: PointVectorSet2D
+        domain_of:
+        - PointSet2D
+        - PointVectorSet2D
+        - PointMatrixSet2D
+        range: float
+      vector2D:
+        name: vector2D
+        description: Orientation vector associated with a point on a 2D image (Nx2).
+        from_schema: https://w3id.org/cetmd/entities
+        array:
+          exact_number_dimensions: 2
+          dimensions:
+          - alias: N
+            minimum_cardinality: 1
+          - alias: xy
+            exact_cardinality: 2
+        alias: vector2D
+        owner: PointVectorSet2D
+        domain_of:
+        - PointVectorSet2D
+        range: float
+      coordinate_systems:
+        name: coordinate_systems
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_systems
+        owner: PointVectorSet2D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateSystem
+        multivalued: true
+      coordinate_transformations:
+        name: coordinate_transformations
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_transformations
+        owner: PointVectorSet2D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateTransformation
+        multivalued: true
+      path:
+        name: path
+        description: Path to a file.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: path
+        owner: PointVectorSet2D
+        domain_of:
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - MovieStack
+        - ProjectionImage
+        - TiltSeries
+        - Tomogram
+        - ParticleMap
+        - Annotation
+        - SubProjectionImage
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: string
+  PointVectorSet3D:
+    name: PointVectorSet3D
+    description: A set of 3D points with an associated direction vector.
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: Annotation
+    mixins:
+    - CoordMetaMixin
+    slots:
+    - origin3D
+    - vector3D
+    attributes:
+      origin3D:
+        name: origin3D
+        description: Location on a 3D image (Nx3).
+        from_schema: https://w3id.org/cetmd/entities
+        array:
+          exact_number_dimensions: 2
+          dimensions:
+          - alias: N
+            minimum_cardinality: 1
+          - alias: xyz
+            exact_cardinality: 3
+        alias: origin3D
+        owner: PointVectorSet3D
+        domain_of:
+        - PointSet3D
+        - PointVectorSet3D
+        - PointMatrixSet3D
+        range: float
+      vector3D:
+        name: vector3D
+        description: Orientation vector associated with a point on a 3D image (Nx3).
+        from_schema: https://w3id.org/cetmd/entities
+        array:
+          exact_number_dimensions: 2
+          dimensions:
+          - alias: N
+            minimum_cardinality: 1
+          - alias: xyz
+            exact_cardinality: 3
+        alias: vector3D
+        owner: PointVectorSet3D
+        domain_of:
+        - PointVectorSet3D
+        range: float
+      coordinate_systems:
+        name: coordinate_systems
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_systems
+        owner: PointVectorSet3D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateSystem
+        multivalued: true
+      coordinate_transformations:
+        name: coordinate_transformations
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_transformations
+        owner: PointVectorSet3D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateTransformation
+        multivalued: true
+      path:
+        name: path
+        description: Path to a file.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: path
+        owner: PointVectorSet3D
+        domain_of:
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - MovieStack
+        - ProjectionImage
+        - TiltSeries
+        - Tomogram
+        - ParticleMap
+        - Annotation
+        - SubProjectionImage
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: string
+  PointMatrixSet2D:
+    name: PointMatrixSet2D
+    description: A set of 2D points with an associated rotation matrix.
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: Annotation
+    mixins:
+    - CoordMetaMixin
+    slots:
+    - origin2D
+    - matrix2D
+    attributes:
+      origin2D:
+        name: origin2D
+        description: Location on a 2D image (Nx2).
+        from_schema: https://w3id.org/cetmd/entities
+        array:
+          exact_number_dimensions: 2
+          dimensions:
+          - alias: N
+            minimum_cardinality: 1
+          - alias: xy
+            exact_cardinality: 2
+        alias: origin2D
+        owner: PointMatrixSet2D
+        domain_of:
+        - PointSet2D
+        - PointVectorSet2D
+        - PointMatrixSet2D
+        range: float
+      matrix2D:
+        name: matrix2D
+        description: Rotation matrix associated with a point on a 2D image (Nx2x2).
+        from_schema: https://w3id.org/cetmd/entities
+        array:
+          exact_number_dimensions: 3
+          dimensions:
+          - alias: N
+            minimum_cardinality: 1
+          - alias: xy
+            exact_cardinality: 2
+          - alias: xy
+            exact_cardinality: 2
+        alias: matrix2D
+        owner: PointMatrixSet2D
+        domain_of:
+        - PointMatrixSet2D
+        range: float
+      coordinate_systems:
+        name: coordinate_systems
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_systems
+        owner: PointMatrixSet2D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateSystem
+        multivalued: true
+      coordinate_transformations:
+        name: coordinate_transformations
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_transformations
+        owner: PointMatrixSet2D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateTransformation
+        multivalued: true
+      path:
+        name: path
+        description: Path to a file.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: path
+        owner: PointMatrixSet2D
+        domain_of:
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - MovieStack
+        - ProjectionImage
+        - TiltSeries
+        - Tomogram
+        - ParticleMap
+        - Annotation
+        - SubProjectionImage
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: string
+  PointMatrixSet3D:
+    name: PointMatrixSet3D
+    description: A set of 3D points with an associated rotation matrix.
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: Annotation
+    mixins:
+    - CoordMetaMixin
+    slots:
+    - origin3D
+    - matrix3D
+    attributes:
+      origin3D:
+        name: origin3D
+        description: Location on a 3D image (Nx3).
+        from_schema: https://w3id.org/cetmd/entities
+        array:
+          exact_number_dimensions: 2
+          dimensions:
+          - alias: N
+            minimum_cardinality: 1
+          - alias: xyz
+            exact_cardinality: 3
+        alias: origin3D
+        owner: PointMatrixSet3D
+        domain_of:
+        - PointSet3D
+        - PointVectorSet3D
+        - PointMatrixSet3D
+        range: float
+      matrix3D:
+        name: matrix3D
+        description: Rotation matrix associated with a point on a 3D image (Nx3x3).
+        from_schema: https://w3id.org/cetmd/entities
+        array:
+          exact_number_dimensions: 3
+          dimensions:
+          - alias: N
+            minimum_cardinality: 1
+          - alias: xyz
+            exact_cardinality: 3
+          - alias: xyz
+            exact_cardinality: 3
+        alias: matrix3D
+        owner: PointMatrixSet3D
+        domain_of:
+        - PointMatrixSet3D
+        range: float
+      coordinate_systems:
+        name: coordinate_systems
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_systems
+        owner: PointMatrixSet3D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateSystem
+        multivalued: true
+      coordinate_transformations:
+        name: coordinate_transformations
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_transformations
+        owner: PointMatrixSet3D
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateTransformation
+        multivalued: true
+      path:
+        name: path
+        description: Path to a file.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: path
+        owner: PointMatrixSet3D
+        domain_of:
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - MovieStack
+        - ProjectionImage
+        - TiltSeries
+        - Tomogram
+        - ParticleMap
+        - Annotation
+        - SubProjectionImage
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: string
+  TriMesh:
+    name: TriMesh
+    description: A mesh annotation.
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: Annotation
+    mixins:
+    - CoordMetaMixin
+    attributes:
+      coordinate_systems:
+        name: coordinate_systems
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_systems
+        owner: TriMesh
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateSystem
+        multivalued: true
+      coordinate_transformations:
+        name: coordinate_transformations
+        description: Named coordinate systems for this entity
+        from_schema: https://w3id.org/cetmd/entities
+        alias: coordinate_transformations
+        owner: TriMesh
+        domain_of:
+        - Image2D
+        - Image3D
+        - CoordMetaMixin
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - ProjectionImage
+        - SubProjectionImage
+        - Tomogram
+        - ParticleMap
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: CoordinateTransformation
+        multivalued: true
+      path:
+        name: path
+        description: Path to a file.
+        from_schema: https://w3id.org/cetmd/entities
+        alias: path
+        owner: TriMesh
+        domain_of:
+        - GainFile
+        - DefectFile
+        - MovieFrame
+        - MovieStack
+        - ProjectionImage
+        - TiltSeries
+        - Tomogram
+        - ParticleMap
+        - Annotation
+        - SubProjectionImage
+        - SegmentationMask2D
+        - SegmentationMask3D
+        - ProbabilityMap2D
+        - ProbabilityMap3D
+        - PointSet2D
+        - PointSet3D
+        - PointVectorSet2D
+        - PointVectorSet3D
+        - PointMatrixSet2D
+        - PointMatrixSet3D
+        range: string
+  ProjectionAlignment:
+    name: ProjectionAlignment
+    description: The tomographic alignment for a single projection.
+    from_schema: https://w3id.org/cetmd/entities
+    is_a: Sequence
+    attributes:
+      input:
+        name: input
+        description: The source coordinate system name
+        from_schema: https://w3id.org/cetmd/alignment/
+        alias: input
+        owner: ProjectionAlignment
+        domain_of:
+        - CoordinateTransformation
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        - Sequence
+        - ProjectionAlignment
+        range: string
+      output:
+        name: output
+        description: The target coordinate system name
+        from_schema: https://w3id.org/cetmd/alignment/
+        alias: output
+        owner: ProjectionAlignment
+        domain_of:
+        - CoordinateTransformation
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        - Sequence
+        - ProjectionAlignment
+        range: string
+      sequence:
+        name: sequence
+        description: The sequence of transformations
+        from_schema: https://w3id.org/cetmd/alignment/
+        alias: sequence
+        owner: ProjectionAlignment
+        domain_of:
+        - Sequence
+        - ProjectionAlignment
+        range: CoordinateTransformation
+        multivalued: true
+        maximum_cardinality: 2
+        any_of:
+        - range: Affine
+        - range: Translation
+      transformation_type:
+        name: transformation_type
+        description: The type of transformation
+        from_schema: https://w3id.org/cetmd/entities
+        ifabsent: sequence
+        alias: transformation_type
+        owner: ProjectionAlignment
+        domain_of:
+        - CoordinateTransformation
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        - Sequence
+        range: TransformationType
+      name:
+        name: name
+        description: The name of the coordinate transformation
+        from_schema: https://w3id.org/cetmd/coord_transforms
+        alias: name
+        owner: ProjectionAlignment
+        domain_of:
+        - Average
+        - Dataset
+        - CoordinateSystem
+        - CoordinateTransformation
+        - Identity
+        - MapAxis
+        - Translation
+        - Scale
+        - Affine
+        - Sequence
+        range: string
+  Alignment:
+    name: Alignment
+    description: The tomographic alignment for a tilt series.
+    from_schema: https://w3id.org/cetmd/entities
+    attributes:
+      projection_alignments:
+        name: projection_alignments
+        description: alignment for a specific projection
+        from_schema: https://w3id.org/cetmd/alignment/
+        alias: projection_alignments
+        owner: Alignment
+        domain_of:
+        - Alignment
+        range: ProjectionAlignment
+        multivalued: true
+source_file: schema/linkml/entities.yaml

--- a/merged.yaml
+++ b/merged.yaml
@@ -1,0 +1,5479 @@
+{
+  "name": "entities",
+  "description": "Schema for cryoET geometry",
+  "id": "https://w3id.org/cetmd/entities",
+  "version": "0.0.1",
+  "prefixes": {
+    "linkml": {
+      "prefix_prefix": "linkml",
+      "prefix_reference": "https://w3id.org/linkml/"
+    },
+    "image_entities": {
+      "prefix_prefix": "image_entities",
+      "prefix_reference": "https://w3id.org/cetmd/image_entities/"
+    },
+    "entities": {
+      "prefix_prefix": "entities",
+      "prefix_reference": "https://w3id.org/cetmd/entities/"
+    },
+    "annotation": {
+      "prefix_prefix": "annotation",
+      "prefix_reference": "https://w3id.org/cetmd/annotation/"
+    },
+    "xsd": {
+      "prefix_prefix": "xsd",
+      "prefix_reference": "http://www.w3.org/2001/XMLSchema#"
+    },
+    "shex": {
+      "prefix_prefix": "shex",
+      "prefix_reference": "http://www.w3.org/ns/shex#"
+    },
+    "schema": {
+      "prefix_prefix": "schema",
+      "prefix_reference": "http://schema.org/"
+    },
+    "image": {
+      "prefix_prefix": "image",
+      "prefix_reference": "https://w3id.org/cetmd/image/"
+    },
+    "coordinate_systems": {
+      "prefix_prefix": "coordinate_systems",
+      "prefix_reference": "https://w3id.org/cetmd/coordinate_systems/"
+    },
+    "coord_transforms": {
+      "prefix_prefix": "coord_transforms",
+      "prefix_reference": "https://w3id.org/cetmd/coord_transforms/"
+    },
+    "annotations": {
+      "prefix_prefix": "annotations",
+      "prefix_reference": "https://w3id.org/cetmd/annotation/"
+    },
+    "alignment": {
+      "prefix_prefix": "alignment",
+      "prefix_reference": "https://w3id.org/cetmd/alignment/"
+    }
+  },
+  "default_prefix": "entities",
+  "types": {
+    "string": {
+      "name": "string",
+      "description": "A character string",
+      "notes": [
+        "In RDF serializations, a slot with range of string is treated as a literal or type xsd:string.   If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"string\"."
+      ],
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "exact_mappings": [
+        "schema:Text"
+      ],
+      "base": "str",
+      "uri": "xsd:string"
+    },
+    "integer": {
+      "name": "integer",
+      "description": "An integer",
+      "notes": [
+        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"integer\"."
+      ],
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "exact_mappings": [
+        "schema:Integer"
+      ],
+      "base": "int",
+      "uri": "xsd:integer"
+    },
+    "boolean": {
+      "name": "boolean",
+      "description": "A binary (true or false) value",
+      "notes": [
+        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"boolean\"."
+      ],
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "exact_mappings": [
+        "schema:Boolean"
+      ],
+      "base": "Bool",
+      "uri": "xsd:boolean",
+      "repr": "bool"
+    },
+    "float": {
+      "name": "float",
+      "description": "A real number that conforms to the xsd:float specification",
+      "notes": [
+        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"float\"."
+      ],
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "exact_mappings": [
+        "schema:Float"
+      ],
+      "base": "float",
+      "uri": "xsd:float"
+    },
+    "double": {
+      "name": "double",
+      "description": "A real number that conforms to the xsd:double specification",
+      "notes": [
+        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"double\"."
+      ],
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "close_mappings": [
+        "schema:Float"
+      ],
+      "base": "float",
+      "uri": "xsd:double"
+    },
+    "decimal": {
+      "name": "decimal",
+      "description": "A real number with arbitrary precision that conforms to the xsd:decimal specification",
+      "notes": [
+        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"decimal\"."
+      ],
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "broad_mappings": [
+        "schema:Number"
+      ],
+      "base": "Decimal",
+      "uri": "xsd:decimal"
+    },
+    "time": {
+      "name": "time",
+      "description": "A time object represents a (local) time of day, independent of any particular day",
+      "notes": [
+        "URI is dateTime because OWL reasoners do not work with straight date or time",
+        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"time\"."
+      ],
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "exact_mappings": [
+        "schema:Time"
+      ],
+      "base": "XSDTime",
+      "uri": "xsd:time",
+      "repr": "str"
+    },
+    "date": {
+      "name": "date",
+      "description": "a date (year, month and day) in an idealized calendar",
+      "notes": [
+        "URI is dateTime because OWL reasoners don't work with straight date or time",
+        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"date\"."
+      ],
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "exact_mappings": [
+        "schema:Date"
+      ],
+      "base": "XSDDate",
+      "uri": "xsd:date",
+      "repr": "str"
+    },
+    "datetime": {
+      "name": "datetime",
+      "description": "The combination of a date and time",
+      "notes": [
+        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"datetime\"."
+      ],
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "exact_mappings": [
+        "schema:DateTime"
+      ],
+      "base": "XSDDateTime",
+      "uri": "xsd:dateTime",
+      "repr": "str"
+    },
+    "date_or_datetime": {
+      "name": "date_or_datetime",
+      "description": "Either a date or a datetime",
+      "notes": [
+        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"date_or_datetime\"."
+      ],
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "base": "str",
+      "uri": "linkml:DateOrDatetime",
+      "repr": "str"
+    },
+    "uriorcurie": {
+      "name": "uriorcurie",
+      "description": "a URI or a CURIE",
+      "notes": [
+        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"uriorcurie\"."
+      ],
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "base": "URIorCURIE",
+      "uri": "xsd:anyURI",
+      "repr": "str"
+    },
+    "curie": {
+      "name": "curie",
+      "conforms_to": "https://www.w3.org/TR/curie/",
+      "description": "a compact URI",
+      "notes": [
+        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"curie\"."
+      ],
+      "comments": [
+        "in RDF serializations this MUST be expanded to a URI",
+        "in non-RDF serializations MAY be serialized as the compact representation"
+      ],
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "base": "Curie",
+      "uri": "xsd:string",
+      "repr": "str"
+    },
+    "uri": {
+      "name": "uri",
+      "conforms_to": "https://www.ietf.org/rfc/rfc3987.txt",
+      "description": "a complete URI",
+      "notes": [
+        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"uri\"."
+      ],
+      "comments": [
+        "in RDF serializations a slot with range of uri is treated as a literal or type xsd:anyURI unless it is an identifier or a reference to an identifier, in which case it is translated directly to a node"
+      ],
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "close_mappings": [
+        "schema:URL"
+      ],
+      "base": "URI",
+      "uri": "xsd:anyURI",
+      "repr": "str"
+    },
+    "ncname": {
+      "name": "ncname",
+      "description": "Prefix part of CURIE",
+      "notes": [
+        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"ncname\"."
+      ],
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "base": "NCName",
+      "uri": "xsd:string",
+      "repr": "str"
+    },
+    "objectidentifier": {
+      "name": "objectidentifier",
+      "description": "A URI or CURIE that represents an object in the model.",
+      "notes": [
+        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"objectidentifier\"."
+      ],
+      "comments": [
+        "Used for inheritance and type checking"
+      ],
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "base": "ElementIdentifier",
+      "uri": "shex:iri",
+      "repr": "str"
+    },
+    "nodeidentifier": {
+      "name": "nodeidentifier",
+      "description": "A URI, CURIE or BNODE that represents a node in a model.",
+      "notes": [
+        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"nodeidentifier\"."
+      ],
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "base": "NodeIdentifier",
+      "uri": "shex:nonLiteral",
+      "repr": "str"
+    },
+    "jsonpointer": {
+      "name": "jsonpointer",
+      "conforms_to": "https://datatracker.ietf.org/doc/html/rfc6901",
+      "description": "A string encoding a JSON Pointer. The value of the string MUST conform to JSON Point syntax and SHOULD dereference to a valid object within the current instance document when encoded in tree form.",
+      "notes": [
+        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"jsonpointer\"."
+      ],
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "base": "str",
+      "uri": "xsd:string",
+      "repr": "str"
+    },
+    "jsonpath": {
+      "name": "jsonpath",
+      "conforms_to": "https://www.ietf.org/archive/id/draft-goessner-dispatch-jsonpath-00.html",
+      "description": "A string encoding a JSON Path. The value of the string MUST conform to JSON Point syntax and SHOULD dereference to zero or more valid objects within the current instance document when encoded in tree form.",
+      "notes": [
+        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"jsonpath\"."
+      ],
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "base": "str",
+      "uri": "xsd:string",
+      "repr": "str"
+    },
+    "sparqlpath": {
+      "name": "sparqlpath",
+      "conforms_to": "https://www.w3.org/TR/sparql11-query/#propertypaths",
+      "description": "A string encoding a SPARQL Property Path. The value of the string MUST conform to SPARQL syntax and SHOULD dereference to zero or more valid objects within the current instance document when encoded as RDF.",
+      "notes": [
+        "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"sparqlpath\"."
+      ],
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "base": "str",
+      "uri": "xsd:string",
+      "repr": "str"
+    }
+  },
+  "enums": {
+    "AxisType": {
+      "name": "AxisType",
+      "description": "The type of axis",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "permissible_values": {
+        "space": {
+          "text": "space",
+          "description": "A spatial axis"
+        },
+        "array": {
+          "text": "array",
+          "description": "An array axis"
+        }
+      }
+    },
+    "TransformationType": {
+      "name": "TransformationType",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "permissible_values": {
+        "identity": {
+          "text": "identity",
+          "description": "The identity transformation."
+        },
+        "map_axis": {
+          "text": "map_axis",
+          "description": "Axis permutation transformation"
+        },
+        "translation": {
+          "text": "translation",
+          "description": "A translation transformation."
+        },
+        "scale": {
+          "text": "scale",
+          "description": "A scaling transformation."
+        },
+        "affine": {
+          "text": "affine",
+          "description": "An affine transformation"
+        },
+        "sequence": {
+          "text": "sequence",
+          "description": "A sequence of transformations"
+        }
+      }
+    }
+  },
+  "slots": {
+    "name": {
+      "name": "name",
+      "description": "The name of a given entry",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "Average",
+        "Dataset",
+        "CoordinateSystem",
+        "CoordinateTransformation"
+      ],
+      "range": "string"
+    },
+    "annotations": {
+      "name": "annotations",
+      "description": "The annotations",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "Region",
+        "Average"
+      ],
+      "range": "Annotation",
+      "multivalued": true
+    },
+    "width": {
+      "name": "width",
+      "description": "The width of the image (x-axis) in pixels",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "Image2D",
+        "Image3D",
+        "GainFile",
+        "DefectFile",
+        "MovieFrame",
+        "ProjectionImage",
+        "SubProjectionImage",
+        "Tomogram",
+        "ParticleMap",
+        "SegmentationMask2D",
+        "SegmentationMask3D",
+        "ProbabilityMap2D"
+      ],
+      "range": "integer"
+    },
+    "height": {
+      "name": "height",
+      "description": "The height of the image (y-axis) in pixels",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "Image2D",
+        "Image3D",
+        "GainFile",
+        "DefectFile",
+        "MovieFrame",
+        "ProjectionImage",
+        "SubProjectionImage",
+        "Tomogram",
+        "ParticleMap",
+        "SegmentationMask2D",
+        "SegmentationMask3D",
+        "ProbabilityMap2D"
+      ],
+      "range": "integer"
+    },
+    "depth": {
+      "name": "depth",
+      "description": "The depth of the image (z-axis) in pixels",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "Image3D",
+        "Tomogram",
+        "ParticleMap",
+        "SegmentationMask3D"
+      ],
+      "range": "integer"
+    },
+    "coordinate_systems": {
+      "name": "coordinate_systems",
+      "description": "Named coordinate systems for this entity",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "Image2D",
+        "Image3D",
+        "CoordMetaMixin",
+        "GainFile",
+        "DefectFile",
+        "MovieFrame",
+        "ProjectionImage",
+        "SubProjectionImage",
+        "Tomogram",
+        "ParticleMap",
+        "SegmentationMask2D",
+        "SegmentationMask3D",
+        "ProbabilityMap2D",
+        "ProbabilityMap3D",
+        "PointSet2D",
+        "PointSet3D",
+        "PointVectorSet2D",
+        "PointVectorSet3D",
+        "PointMatrixSet2D",
+        "PointMatrixSet3D"
+      ],
+      "range": "CoordinateSystem",
+      "multivalued": true
+    },
+    "coordinate_transformations": {
+      "name": "coordinate_transformations",
+      "description": "Named coordinate systems for this entity",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "Image2D",
+        "Image3D",
+        "CoordMetaMixin",
+        "GainFile",
+        "DefectFile",
+        "MovieFrame",
+        "ProjectionImage",
+        "SubProjectionImage",
+        "Tomogram",
+        "ParticleMap",
+        "SegmentationMask2D",
+        "SegmentationMask3D",
+        "ProbabilityMap2D",
+        "ProbabilityMap3D",
+        "PointSet2D",
+        "PointSet3D",
+        "PointVectorSet2D",
+        "PointVectorSet3D",
+        "PointMatrixSet2D",
+        "PointMatrixSet3D"
+      ],
+      "range": "CoordinateTransformation",
+      "multivalued": true
+    },
+    "images2D": {
+      "name": "images2D",
+      "description": "The images in the stack",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "ImageStack2D"
+      ],
+      "range": "Image2D",
+      "multivalued": true
+    },
+    "images3D": {
+      "name": "images3D",
+      "description": "The images in the stack",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "ImageStack3D"
+      ],
+      "range": "Image3D",
+      "multivalued": true
+    },
+    "axis_name": {
+      "name": "axis_name",
+      "description": "The name of the axis",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "Axis"
+      ],
+      "range": "string"
+    },
+    "axis_unit": {
+      "name": "axis_unit",
+      "description": "The unit of the axis",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "ifabsent": "angstrom",
+      "domain_of": [
+        "Axis"
+      ],
+      "range": "string"
+    },
+    "axis_type": {
+      "name": "axis_type",
+      "description": "The type of axis",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "Axis"
+      ],
+      "range": "AxisType"
+    },
+    "transformation_type": {
+      "name": "transformation_type",
+      "description": "The type of transformation",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "CoordinateTransformation",
+        "Identity",
+        "MapAxis",
+        "Translation",
+        "Scale",
+        "Affine",
+        "Sequence"
+      ],
+      "range": "TransformationType"
+    },
+    "path": {
+      "name": "path",
+      "description": "Path to a file.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "GainFile",
+        "DefectFile",
+        "MovieFrame",
+        "MovieStack",
+        "ProjectionImage",
+        "TiltSeries",
+        "Tomogram",
+        "ParticleMap",
+        "Annotation",
+        "SubProjectionImage",
+        "SegmentationMask2D",
+        "SegmentationMask3D",
+        "ProbabilityMap2D",
+        "ProbabilityMap3D",
+        "PointSet2D",
+        "PointSet3D",
+        "PointVectorSet2D",
+        "PointVectorSet3D",
+        "PointMatrixSet2D",
+        "PointMatrixSet3D"
+      ],
+      "range": "string"
+    },
+    "section": {
+      "name": "section",
+      "description": "0-based section index to the entity inside a stack.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "MovieFrame",
+        "ProjectionImage"
+      ],
+      "range": "integer"
+    },
+    "nominal_tilt_angle": {
+      "name": "nominal_tilt_angle",
+      "description": "The tilt angle reported by the microscope",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "AcquisitionMetadataMixin",
+        "MovieFrame",
+        "ProjectionImage"
+      ],
+      "range": "float"
+    },
+    "accumulated_dose": {
+      "name": "accumulated_dose",
+      "description": "The pre-exposure up to this image in e-/A^2",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "AcquisitionMetadataMixin",
+        "MovieFrame",
+        "ProjectionImage"
+      ],
+      "range": "float"
+    },
+    "defocus_u": {
+      "name": "defocus_u",
+      "description": "Estimated defocus U for this image in Angstrom, underfocus positive.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "CTFMetadata"
+      ],
+      "range": "float"
+    },
+    "defocus_v": {
+      "name": "defocus_v",
+      "description": "Estimated defocus V for this image in Angstrom, underfocus positive.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "CTFMetadata"
+      ],
+      "range": "float"
+    },
+    "defocus_angle": {
+      "name": "defocus_angle",
+      "description": "Estimated angle of astigmatism.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "CTFMetadata"
+      ],
+      "range": "float"
+    },
+    "particle_index": {
+      "name": "particle_index",
+      "description": "Index of a particle inside a tomogram.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "SubProjectionImage"
+      ],
+      "range": "integer"
+    },
+    "ctf_metadata": {
+      "name": "ctf_metadata",
+      "description": "A set of CTF patameters for an image.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "AcquisitionMetadataMixin",
+        "MovieFrame",
+        "ProjectionImage"
+      ],
+      "range": "CTFMetadata"
+    },
+    "images_movie": {
+      "name": "images_movie",
+      "description": "The movie frames in the stack",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "MovieStack"
+      ],
+      "range": "MovieFrame",
+      "multivalued": true
+    },
+    "images_tilt": {
+      "name": "images_tilt",
+      "description": "The projections in the stack",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "domain_of": [
+        "TiltSeries"
+      ],
+      "range": "ProjectionImage",
+      "multivalued": true
+    },
+    "origin2D": {
+      "name": "origin2D",
+      "description": "Location on a 2D image (Nx2).",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "array": {
+        "exact_number_dimensions": 2,
+        "dimensions": [
+          {
+            "alias": "N",
+            "minimum_cardinality": 1
+          },
+          {
+            "alias": "xy",
+            "exact_cardinality": 2
+          }
+        ]
+      },
+      "domain_of": [
+        "PointSet2D",
+        "PointVectorSet2D",
+        "PointMatrixSet2D"
+      ],
+      "range": "float"
+    },
+    "translation2D": {
+      "name": "translation2D",
+      "description": "Offset from the origin of a point on a 2D image (Nx2).",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "array": {
+        "exact_number_dimensions": 2,
+        "dimensions": [
+          {
+            "alias": "N",
+            "minimum_cardinality": 1
+          },
+          {
+            "alias": "xy",
+            "exact_cardinality": 2
+          }
+        ]
+      },
+      "range": "float"
+    },
+    "vector2D": {
+      "name": "vector2D",
+      "description": "Orientation vector associated with a point on a 2D image (Nx2).",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "array": {
+        "exact_number_dimensions": 2,
+        "dimensions": [
+          {
+            "alias": "N",
+            "minimum_cardinality": 1
+          },
+          {
+            "alias": "xy",
+            "exact_cardinality": 2
+          }
+        ]
+      },
+      "domain_of": [
+        "PointVectorSet2D"
+      ],
+      "range": "float"
+    },
+    "matrix2D": {
+      "name": "matrix2D",
+      "description": "Rotation matrix associated with a point on a 2D image (Nx2x2).",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "array": {
+        "exact_number_dimensions": 3,
+        "dimensions": [
+          {
+            "alias": "N",
+            "minimum_cardinality": 1
+          },
+          {
+            "alias": "xy",
+            "exact_cardinality": 2
+          },
+          {
+            "alias": "xy",
+            "exact_cardinality": 2
+          }
+        ]
+      },
+      "domain_of": [
+        "PointMatrixSet2D"
+      ],
+      "range": "float"
+    },
+    "origin3D": {
+      "name": "origin3D",
+      "description": "Location on a 3D image (Nx3).",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "array": {
+        "exact_number_dimensions": 2,
+        "dimensions": [
+          {
+            "alias": "N",
+            "minimum_cardinality": 1
+          },
+          {
+            "alias": "xyz",
+            "exact_cardinality": 3
+          }
+        ]
+      },
+      "domain_of": [
+        "PointSet3D",
+        "PointVectorSet3D",
+        "PointMatrixSet3D"
+      ],
+      "range": "float"
+    },
+    "translation3D": {
+      "name": "translation3D",
+      "description": "Offset from the origin of a point on a 3D image (Nx3).",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "array": {
+        "exact_number_dimensions": 2,
+        "dimensions": [
+          {
+            "alias": "N",
+            "minimum_cardinality": 1
+          },
+          {
+            "alias": "xyz",
+            "exact_cardinality": 3
+          }
+        ]
+      },
+      "range": "float"
+    },
+    "vector3D": {
+      "name": "vector3D",
+      "description": "Orientation vector associated with a point on a 3D image (Nx3).",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "array": {
+        "exact_number_dimensions": 2,
+        "dimensions": [
+          {
+            "alias": "N",
+            "minimum_cardinality": 1
+          },
+          {
+            "alias": "xyz",
+            "exact_cardinality": 3
+          }
+        ]
+      },
+      "domain_of": [
+        "PointVectorSet3D"
+      ],
+      "range": "float"
+    },
+    "matrix3D": {
+      "name": "matrix3D",
+      "description": "Rotation matrix associated with a point on a 3D image (Nx3x3).",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "array": {
+        "exact_number_dimensions": 3,
+        "dimensions": [
+          {
+            "alias": "N",
+            "minimum_cardinality": 1
+          },
+          {
+            "alias": "xyz",
+            "exact_cardinality": 3
+          },
+          {
+            "alias": "xyz",
+            "exact_cardinality": 3
+          }
+        ]
+      },
+      "domain_of": [
+        "PointMatrixSet3D"
+      ],
+      "range": "float"
+    }
+  },
+  "classes": {
+    "Region": {
+      "name": "Region",
+      "description": "Raw data (movie stacks) and derived data (tilt series, tomograms, annotations) from a single region of a specimen.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "slots": [
+        "annotations"
+      ],
+      "attributes": {
+        "movie_stack_collections": {
+          "name": "movie_stack_collections",
+          "description": "The movie stack",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "movie_stack_collections",
+          "owner": "Region",
+          "domain_of": [
+            "Region"
+          ],
+          "range": "MovieStackCollection",
+          "multivalued": true
+        },
+        "tilt_series": {
+          "name": "tilt_series",
+          "description": "The tilt series",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "tilt_series",
+          "owner": "Region",
+          "domain_of": [
+            "Region"
+          ],
+          "range": "TiltSeries",
+          "multivalued": true
+        },
+        "alignments": {
+          "name": "alignments",
+          "description": "The alignments",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "alignments",
+          "owner": "Region",
+          "domain_of": [
+            "Region"
+          ],
+          "range": "Alignment",
+          "multivalued": true
+        },
+        "tomograms": {
+          "name": "tomograms",
+          "description": "The tomograms",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "tomograms",
+          "owner": "Region",
+          "domain_of": [
+            "Region"
+          ],
+          "range": "Tomogram",
+          "multivalued": true
+        },
+        "annotations": {
+          "name": "annotations",
+          "description": "The annotations",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "annotations",
+          "owner": "Region",
+          "domain_of": [
+            "Region",
+            "Average"
+          ],
+          "range": "Annotation",
+          "multivalued": true
+        }
+      }
+    },
+    "Average": {
+      "name": "Average",
+      "description": "A particle averaging experiment.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "slots": [
+        "name",
+        "annotations"
+      ],
+      "attributes": {
+        "particle_maps": {
+          "name": "particle_maps",
+          "description": "The particle maps",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "particle_maps",
+          "owner": "Average",
+          "domain_of": [
+            "Average"
+          ],
+          "range": "ParticleMap",
+          "multivalued": true
+        },
+        "name": {
+          "name": "name",
+          "description": "The name of a given entry",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "name",
+          "owner": "Average",
+          "domain_of": [
+            "Average",
+            "Dataset",
+            "CoordinateSystem",
+            "CoordinateTransformation"
+          ],
+          "range": "string"
+        },
+        "annotations": {
+          "name": "annotations",
+          "description": "The annotations",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "annotations",
+          "owner": "Average",
+          "domain_of": [
+            "Region",
+            "Average"
+          ],
+          "range": "Annotation",
+          "multivalued": true
+        }
+      }
+    },
+    "MovieStackCollection": {
+      "name": "MovieStackCollection",
+      "description": "A collection of movie stacks using the same gain and defect files.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "attributes": {
+        "movie_stacks": {
+          "name": "movie_stacks",
+          "description": "The movie stacks in the collection",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "movie_stacks",
+          "owner": "MovieStackCollection",
+          "domain_of": [
+            "MovieStackCollection"
+          ],
+          "range": "MovieStackSeries",
+          "multivalued": true
+        },
+        "gain_file": {
+          "name": "gain_file",
+          "description": "The gain file for the movie stacks",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "gain_file",
+          "owner": "MovieStackCollection",
+          "domain_of": [
+            "MovieStackCollection"
+          ],
+          "range": "GainFile"
+        },
+        "defect_file": {
+          "name": "defect_file",
+          "description": "The defect file for the movie stacks",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "defect_file",
+          "owner": "MovieStackCollection",
+          "domain_of": [
+            "MovieStackCollection"
+          ],
+          "range": "DefectFile"
+        }
+      }
+    },
+    "Dataset": {
+      "name": "Dataset",
+      "description": "A dataset",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "slots": [
+        "name"
+      ],
+      "attributes": {
+        "regions": {
+          "name": "regions",
+          "description": "The regions in the dataset",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "regions",
+          "owner": "Dataset",
+          "domain_of": [
+            "Dataset"
+          ],
+          "range": "Region",
+          "multivalued": true
+        },
+        "averages": {
+          "name": "averages",
+          "description": "The averages in the dataset",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "averages",
+          "owner": "Dataset",
+          "domain_of": [
+            "Dataset"
+          ],
+          "range": "Average",
+          "multivalued": true
+        },
+        "name": {
+          "name": "name",
+          "description": "The name of a given entry",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "name",
+          "owner": "Dataset",
+          "domain_of": [
+            "Average",
+            "Dataset",
+            "CoordinateSystem",
+            "CoordinateTransformation"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "Image2D": {
+      "name": "Image2D",
+      "description": "A 2D image.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "slots": [
+        "width",
+        "height",
+        "coordinate_systems",
+        "coordinate_transformations"
+      ],
+      "attributes": {
+        "width": {
+          "name": "width",
+          "description": "The width of the image (x-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "width",
+          "owner": "Image2D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "height": {
+          "name": "height",
+          "description": "The height of the image (y-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "height",
+          "owner": "Image2D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "coordinate_systems": {
+          "name": "coordinate_systems",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_systems",
+          "owner": "Image2D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateSystem",
+          "multivalued": true
+        },
+        "coordinate_transformations": {
+          "name": "coordinate_transformations",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_transformations",
+          "owner": "Image2D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        }
+      }
+    },
+    "Image3D": {
+      "name": "Image3D",
+      "description": "A 3D image.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "slots": [
+        "width",
+        "height",
+        "depth",
+        "coordinate_systems",
+        "coordinate_transformations"
+      ],
+      "attributes": {
+        "width": {
+          "name": "width",
+          "description": "The width of the image (x-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "width",
+          "owner": "Image3D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "height": {
+          "name": "height",
+          "description": "The height of the image (y-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "height",
+          "owner": "Image3D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "depth": {
+          "name": "depth",
+          "description": "The depth of the image (z-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "depth",
+          "owner": "Image3D",
+          "domain_of": [
+            "Image3D",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask3D"
+          ],
+          "range": "integer"
+        },
+        "coordinate_systems": {
+          "name": "coordinate_systems",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_systems",
+          "owner": "Image3D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateSystem",
+          "multivalued": true
+        },
+        "coordinate_transformations": {
+          "name": "coordinate_transformations",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_transformations",
+          "owner": "Image3D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        }
+      }
+    },
+    "ImageStack2D": {
+      "name": "ImageStack2D",
+      "description": "A stack of 2D images.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "slots": [
+        "images2D"
+      ],
+      "attributes": {
+        "images2D": {
+          "name": "images2D",
+          "description": "The images in the stack",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "images2D",
+          "owner": "ImageStack2D",
+          "domain_of": [
+            "ImageStack2D"
+          ],
+          "range": "Image2D",
+          "multivalued": true
+        }
+      }
+    },
+    "ImageStack3D": {
+      "name": "ImageStack3D",
+      "description": "A stack of 3D images.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "slots": [
+        "images3D"
+      ],
+      "attributes": {
+        "images3D": {
+          "name": "images3D",
+          "description": "The images in the stack",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "images3D",
+          "owner": "ImageStack3D",
+          "domain_of": [
+            "ImageStack3D"
+          ],
+          "range": "Image3D",
+          "multivalued": true
+        }
+      }
+    },
+    "Axis": {
+      "name": "Axis",
+      "description": "An axis in a coordinate system",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "slots": [
+        "axis_name",
+        "axis_unit",
+        "axis_type"
+      ],
+      "attributes": {
+        "axis_name": {
+          "name": "axis_name",
+          "description": "The name of the axis",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "axis_name",
+          "owner": "Axis",
+          "domain_of": [
+            "Axis"
+          ],
+          "range": "string"
+        },
+        "axis_unit": {
+          "name": "axis_unit",
+          "description": "The unit of the axis",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "ifabsent": "angstrom",
+          "alias": "axis_unit",
+          "owner": "Axis",
+          "domain_of": [
+            "Axis"
+          ],
+          "range": "string"
+        },
+        "axis_type": {
+          "name": "axis_type",
+          "description": "The type of axis",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "axis_type",
+          "owner": "Axis",
+          "domain_of": [
+            "Axis"
+          ],
+          "range": "AxisType"
+        }
+      }
+    },
+    "CoordinateSystem": {
+      "name": "CoordinateSystem",
+      "description": "A coordinate system",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "attributes": {
+        "name": {
+          "name": "name",
+          "description": "The name of the coordinate system",
+          "from_schema": "https://w3id.org/cetmd/coordinate_systems",
+          "alias": "name",
+          "owner": "CoordinateSystem",
+          "domain_of": [
+            "Average",
+            "Dataset",
+            "CoordinateSystem",
+            "CoordinateTransformation"
+          ],
+          "range": "string",
+          "required": true
+        },
+        "axes": {
+          "name": "axes",
+          "description": "The axes of the coordinate system",
+          "from_schema": "https://w3id.org/cetmd/coordinate_systems",
+          "alias": "axes",
+          "owner": "CoordinateSystem",
+          "domain_of": [
+            "CoordinateSystem"
+          ],
+          "range": "Axis",
+          "required": true,
+          "multivalued": true
+        }
+      }
+    },
+    "CoordinateTransformation": {
+      "name": "CoordinateTransformation",
+      "description": "A coordinate transformation",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "slots": [
+        "transformation_type"
+      ],
+      "attributes": {
+        "name": {
+          "name": "name",
+          "description": "The name of the coordinate transformation",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "name",
+          "owner": "CoordinateTransformation",
+          "domain_of": [
+            "Average",
+            "Dataset",
+            "CoordinateSystem",
+            "CoordinateTransformation",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine",
+            "Sequence"
+          ],
+          "range": "string"
+        },
+        "input": {
+          "name": "input",
+          "description": "The source coordinate system name",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "input",
+          "owner": "CoordinateTransformation",
+          "domain_of": [
+            "CoordinateTransformation",
+            "ProjectionAlignment",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine"
+          ],
+          "range": "string"
+        },
+        "output": {
+          "name": "output",
+          "description": "The target coordinate system name",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "output",
+          "owner": "CoordinateTransformation",
+          "domain_of": [
+            "CoordinateTransformation",
+            "ProjectionAlignment",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine"
+          ],
+          "range": "string"
+        },
+        "transformation_type": {
+          "name": "transformation_type",
+          "description": "The type of transformation",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "transformation_type",
+          "owner": "CoordinateTransformation",
+          "domain_of": [
+            "CoordinateTransformation",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine",
+            "Sequence"
+          ],
+          "range": "TransformationType"
+        }
+      }
+    },
+    "Identity": {
+      "name": "Identity",
+      "description": "The identity transformation",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "CoordinateTransformation",
+      "slots": [
+        "transformation_type"
+      ],
+      "slot_usage": {
+        "transformation_type": {
+          "name": "transformation_type",
+          "ifabsent": "identity"
+        }
+      },
+      "attributes": {
+        "transformation_type": {
+          "name": "transformation_type",
+          "description": "The type of transformation",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "ifabsent": "identity",
+          "alias": "transformation_type",
+          "owner": "Identity",
+          "domain_of": [
+            "CoordinateTransformation",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine",
+            "Sequence"
+          ],
+          "range": "TransformationType"
+        },
+        "name": {
+          "name": "name",
+          "description": "The name of the coordinate transformation",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "name",
+          "owner": "Identity",
+          "domain_of": [
+            "Average",
+            "Dataset",
+            "CoordinateSystem",
+            "CoordinateTransformation",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine",
+            "Sequence"
+          ],
+          "range": "string"
+        },
+        "input": {
+          "name": "input",
+          "description": "The source coordinate system name",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "input",
+          "owner": "Identity",
+          "domain_of": [
+            "CoordinateTransformation",
+            "ProjectionAlignment",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine"
+          ],
+          "range": "string"
+        },
+        "output": {
+          "name": "output",
+          "description": "The target coordinate system name",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "output",
+          "owner": "Identity",
+          "domain_of": [
+            "CoordinateTransformation",
+            "ProjectionAlignment",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "AxisNameMapping": {
+      "name": "AxisNameMapping",
+      "description": "Axis name to Axis name mapping",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "attributes": {
+        "axis1_name": {
+          "name": "axis1_name",
+          "description": "The type of transformation",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "axis1_name",
+          "owner": "AxisNameMapping",
+          "domain_of": [
+            "AxisNameMapping"
+          ],
+          "range": "string"
+        },
+        "axis2_name": {
+          "name": "axis2_name",
+          "description": "The mapping of the axis names",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "axis2_name",
+          "owner": "AxisNameMapping",
+          "domain_of": [
+            "AxisNameMapping"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "MapAxis": {
+      "name": "MapAxis",
+      "description": "Axis permutation transformation",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "CoordinateTransformation",
+      "slots": [
+        "transformation_type"
+      ],
+      "slot_usage": {
+        "transformation_type": {
+          "name": "transformation_type",
+          "ifabsent": "map_axis"
+        }
+      },
+      "attributes": {
+        "map_axis": {
+          "name": "map_axis",
+          "description": "The permutation of the axes",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "map_axis",
+          "owner": "MapAxis",
+          "domain_of": [
+            "MapAxis"
+          ],
+          "range": "AxisNameMapping",
+          "multivalued": true,
+          "inlined": true
+        },
+        "transformation_type": {
+          "name": "transformation_type",
+          "description": "The type of transformation",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "ifabsent": "map_axis",
+          "alias": "transformation_type",
+          "owner": "MapAxis",
+          "domain_of": [
+            "CoordinateTransformation",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine",
+            "Sequence"
+          ],
+          "range": "TransformationType"
+        },
+        "name": {
+          "name": "name",
+          "description": "The name of the coordinate transformation",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "name",
+          "owner": "MapAxis",
+          "domain_of": [
+            "Average",
+            "Dataset",
+            "CoordinateSystem",
+            "CoordinateTransformation",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine",
+            "Sequence"
+          ],
+          "range": "string"
+        },
+        "input": {
+          "name": "input",
+          "description": "The source coordinate system name",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "input",
+          "owner": "MapAxis",
+          "domain_of": [
+            "CoordinateTransformation",
+            "ProjectionAlignment",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine"
+          ],
+          "range": "string"
+        },
+        "output": {
+          "name": "output",
+          "description": "The target coordinate system name",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "output",
+          "owner": "MapAxis",
+          "domain_of": [
+            "CoordinateTransformation",
+            "ProjectionAlignment",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "Translation": {
+      "name": "Translation",
+      "description": "A translation transformation",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "CoordinateTransformation",
+      "slots": [
+        "transformation_type"
+      ],
+      "slot_usage": {
+        "transformation_type": {
+          "name": "transformation_type",
+          "ifabsent": "translation"
+        }
+      },
+      "attributes": {
+        "translation": {
+          "name": "translation",
+          "description": "The translation vector",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "translation",
+          "owner": "Translation",
+          "domain_of": [
+            "Translation"
+          ],
+          "range": "float",
+          "multivalued": true
+        },
+        "transformation_type": {
+          "name": "transformation_type",
+          "description": "The type of transformation",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "ifabsent": "translation",
+          "alias": "transformation_type",
+          "owner": "Translation",
+          "domain_of": [
+            "CoordinateTransformation",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine",
+            "Sequence"
+          ],
+          "range": "TransformationType"
+        },
+        "name": {
+          "name": "name",
+          "description": "The name of the coordinate transformation",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "name",
+          "owner": "Translation",
+          "domain_of": [
+            "Average",
+            "Dataset",
+            "CoordinateSystem",
+            "CoordinateTransformation",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine",
+            "Sequence"
+          ],
+          "range": "string"
+        },
+        "input": {
+          "name": "input",
+          "description": "The source coordinate system name",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "input",
+          "owner": "Translation",
+          "domain_of": [
+            "CoordinateTransformation",
+            "ProjectionAlignment",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine"
+          ],
+          "range": "string"
+        },
+        "output": {
+          "name": "output",
+          "description": "The target coordinate system name",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "output",
+          "owner": "Translation",
+          "domain_of": [
+            "CoordinateTransformation",
+            "ProjectionAlignment",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "Scale": {
+      "name": "Scale",
+      "description": "A scaling transformation",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "CoordinateTransformation",
+      "slots": [
+        "transformation_type"
+      ],
+      "slot_usage": {
+        "transformation_type": {
+          "name": "transformation_type",
+          "ifabsent": "scale"
+        }
+      },
+      "attributes": {
+        "scale": {
+          "name": "scale",
+          "description": "The scaling vector",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "scale",
+          "owner": "Scale",
+          "domain_of": [
+            "Scale"
+          ],
+          "range": "float",
+          "multivalued": true
+        },
+        "transformation_type": {
+          "name": "transformation_type",
+          "description": "The type of transformation",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "ifabsent": "scale",
+          "alias": "transformation_type",
+          "owner": "Scale",
+          "domain_of": [
+            "CoordinateTransformation",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine",
+            "Sequence"
+          ],
+          "range": "TransformationType"
+        },
+        "name": {
+          "name": "name",
+          "description": "The name of the coordinate transformation",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "name",
+          "owner": "Scale",
+          "domain_of": [
+            "Average",
+            "Dataset",
+            "CoordinateSystem",
+            "CoordinateTransformation",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine",
+            "Sequence"
+          ],
+          "range": "string"
+        },
+        "input": {
+          "name": "input",
+          "description": "The source coordinate system name",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "input",
+          "owner": "Scale",
+          "domain_of": [
+            "CoordinateTransformation",
+            "ProjectionAlignment",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine"
+          ],
+          "range": "string"
+        },
+        "output": {
+          "name": "output",
+          "description": "The target coordinate system name",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "output",
+          "owner": "Scale",
+          "domain_of": [
+            "CoordinateTransformation",
+            "ProjectionAlignment",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "Affine": {
+      "name": "Affine",
+      "description": "An affine transformation",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "CoordinateTransformation",
+      "slots": [
+        "transformation_type"
+      ],
+      "slot_usage": {
+        "transformation_type": {
+          "name": "transformation_type",
+          "ifabsent": "affine"
+        }
+      },
+      "attributes": {
+        "affine": {
+          "name": "affine",
+          "description": "The affine matrix",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "array": {
+            "exact_number_dimensions": 2,
+            "dimensions": [
+              {
+                "alias": "exact_card",
+                "exact_cardinality": 3
+              },
+              {
+                "alias": "exact_card",
+                "exact_cardinality": 3
+              }
+            ]
+          },
+          "alias": "affine",
+          "owner": "Affine",
+          "domain_of": [
+            "Affine"
+          ],
+          "range": "integer"
+        },
+        "transformation_type": {
+          "name": "transformation_type",
+          "description": "The type of transformation",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "ifabsent": "affine",
+          "alias": "transformation_type",
+          "owner": "Affine",
+          "domain_of": [
+            "CoordinateTransformation",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine",
+            "Sequence"
+          ],
+          "range": "TransformationType"
+        },
+        "name": {
+          "name": "name",
+          "description": "The name of the coordinate transformation",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "name",
+          "owner": "Affine",
+          "domain_of": [
+            "Average",
+            "Dataset",
+            "CoordinateSystem",
+            "CoordinateTransformation",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine",
+            "Sequence"
+          ],
+          "range": "string"
+        },
+        "input": {
+          "name": "input",
+          "description": "The source coordinate system name",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "input",
+          "owner": "Affine",
+          "domain_of": [
+            "CoordinateTransformation",
+            "ProjectionAlignment",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine"
+          ],
+          "range": "string"
+        },
+        "output": {
+          "name": "output",
+          "description": "The target coordinate system name",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "output",
+          "owner": "Affine",
+          "domain_of": [
+            "CoordinateTransformation",
+            "ProjectionAlignment",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "Sequence": {
+      "name": "Sequence",
+      "description": "A sequence of transformations",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "CoordinateTransformation",
+      "slots": [
+        "transformation_type"
+      ],
+      "slot_usage": {
+        "transformation_type": {
+          "name": "transformation_type",
+          "ifabsent": "sequence"
+        }
+      },
+      "attributes": {
+        "sequence": {
+          "name": "sequence",
+          "description": "The sequence of transformations",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "sequence",
+          "owner": "Sequence",
+          "domain_of": [
+            "Sequence",
+            "ProjectionAlignment"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        },
+        "transformation_type": {
+          "name": "transformation_type",
+          "description": "The type of transformation",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "ifabsent": "sequence",
+          "alias": "transformation_type",
+          "owner": "Sequence",
+          "domain_of": [
+            "CoordinateTransformation",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine",
+            "Sequence"
+          ],
+          "range": "TransformationType"
+        },
+        "name": {
+          "name": "name",
+          "description": "The name of the coordinate transformation",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "name",
+          "owner": "Sequence",
+          "domain_of": [
+            "Average",
+            "Dataset",
+            "CoordinateSystem",
+            "CoordinateTransformation",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine",
+            "Sequence"
+          ],
+          "range": "string"
+        },
+        "input": {
+          "name": "input",
+          "description": "The source coordinate system name",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "input",
+          "owner": "Sequence",
+          "domain_of": [
+            "CoordinateTransformation",
+            "ProjectionAlignment",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine"
+          ],
+          "range": "string"
+        },
+        "output": {
+          "name": "output",
+          "description": "The target coordinate system name",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "output",
+          "owner": "Sequence",
+          "domain_of": [
+            "CoordinateTransformation",
+            "ProjectionAlignment",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "CTFMetadata": {
+      "name": "CTFMetadata",
+      "description": "A set of CTF patameters for an image.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "slots": [
+        "defocus_u",
+        "defocus_v",
+        "defocus_angle"
+      ],
+      "attributes": {
+        "defocus_u": {
+          "name": "defocus_u",
+          "description": "Estimated defocus U for this image in Angstrom, underfocus positive.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "defocus_u",
+          "owner": "CTFMetadata",
+          "domain_of": [
+            "CTFMetadata"
+          ],
+          "range": "float"
+        },
+        "defocus_v": {
+          "name": "defocus_v",
+          "description": "Estimated defocus V for this image in Angstrom, underfocus positive.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "defocus_v",
+          "owner": "CTFMetadata",
+          "domain_of": [
+            "CTFMetadata"
+          ],
+          "range": "float"
+        },
+        "defocus_angle": {
+          "name": "defocus_angle",
+          "description": "Estimated angle of astigmatism.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "defocus_angle",
+          "owner": "CTFMetadata",
+          "domain_of": [
+            "CTFMetadata"
+          ],
+          "range": "float"
+        }
+      }
+    },
+    "AcquisitionMetadataMixin": {
+      "name": "AcquisitionMetadataMixin",
+      "description": "Metadata concerning the acquisition process.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "slots": [
+        "nominal_tilt_angle",
+        "accumulated_dose",
+        "ctf_metadata"
+      ],
+      "attributes": {
+        "nominal_tilt_angle": {
+          "name": "nominal_tilt_angle",
+          "description": "The tilt angle reported by the microscope",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "nominal_tilt_angle",
+          "owner": "AcquisitionMetadataMixin",
+          "domain_of": [
+            "AcquisitionMetadataMixin",
+            "MovieFrame",
+            "ProjectionImage"
+          ],
+          "range": "float"
+        },
+        "accumulated_dose": {
+          "name": "accumulated_dose",
+          "description": "The pre-exposure up to this image in e-/A^2",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "accumulated_dose",
+          "owner": "AcquisitionMetadataMixin",
+          "domain_of": [
+            "AcquisitionMetadataMixin",
+            "MovieFrame",
+            "ProjectionImage"
+          ],
+          "range": "float"
+        },
+        "ctf_metadata": {
+          "name": "ctf_metadata",
+          "description": "A set of CTF patameters for an image.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "ctf_metadata",
+          "owner": "AcquisitionMetadataMixin",
+          "domain_of": [
+            "AcquisitionMetadataMixin",
+            "MovieFrame",
+            "ProjectionImage"
+          ],
+          "range": "CTFMetadata"
+        }
+      }
+    },
+    "GainFile": {
+      "name": "GainFile",
+      "description": "A gain reference file.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "Image2D",
+      "slots": [
+        "path"
+      ],
+      "attributes": {
+        "path": {
+          "name": "path",
+          "description": "Path to a file.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "path",
+          "owner": "GainFile",
+          "domain_of": [
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "MovieStack",
+            "ProjectionImage",
+            "TiltSeries",
+            "Tomogram",
+            "ParticleMap",
+            "Annotation",
+            "SubProjectionImage",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "string"
+        },
+        "width": {
+          "name": "width",
+          "description": "The width of the image (x-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "width",
+          "owner": "GainFile",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "height": {
+          "name": "height",
+          "description": "The height of the image (y-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "height",
+          "owner": "GainFile",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "coordinate_systems": {
+          "name": "coordinate_systems",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_systems",
+          "owner": "GainFile",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateSystem",
+          "multivalued": true
+        },
+        "coordinate_transformations": {
+          "name": "coordinate_transformations",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_transformations",
+          "owner": "GainFile",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        }
+      }
+    },
+    "DefectFile": {
+      "name": "DefectFile",
+      "description": "A detector defect file.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "Image2D",
+      "slots": [
+        "path"
+      ],
+      "attributes": {
+        "path": {
+          "name": "path",
+          "description": "Path to a file.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "path",
+          "owner": "DefectFile",
+          "domain_of": [
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "MovieStack",
+            "ProjectionImage",
+            "TiltSeries",
+            "Tomogram",
+            "ParticleMap",
+            "Annotation",
+            "SubProjectionImage",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "string"
+        },
+        "width": {
+          "name": "width",
+          "description": "The width of the image (x-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "width",
+          "owner": "DefectFile",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "height": {
+          "name": "height",
+          "description": "The height of the image (y-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "height",
+          "owner": "DefectFile",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "coordinate_systems": {
+          "name": "coordinate_systems",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_systems",
+          "owner": "DefectFile",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateSystem",
+          "multivalued": true
+        },
+        "coordinate_transformations": {
+          "name": "coordinate_transformations",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_transformations",
+          "owner": "DefectFile",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        }
+      }
+    },
+    "MovieFrame": {
+      "name": "MovieFrame",
+      "description": "An individual movie frame",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "Image2D",
+      "mixins": [
+        "AcquisitionMetadataMixin"
+      ],
+      "slots": [
+        "path",
+        "section"
+      ],
+      "attributes": {
+        "path": {
+          "name": "path",
+          "description": "Path to a file.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "path",
+          "owner": "MovieFrame",
+          "domain_of": [
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "MovieStack",
+            "ProjectionImage",
+            "TiltSeries",
+            "Tomogram",
+            "ParticleMap",
+            "Annotation",
+            "SubProjectionImage",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "string"
+        },
+        "section": {
+          "name": "section",
+          "description": "0-based section index to the entity inside a stack.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "section",
+          "owner": "MovieFrame",
+          "domain_of": [
+            "MovieFrame",
+            "ProjectionImage"
+          ],
+          "range": "integer"
+        },
+        "nominal_tilt_angle": {
+          "name": "nominal_tilt_angle",
+          "description": "The tilt angle reported by the microscope",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "nominal_tilt_angle",
+          "owner": "MovieFrame",
+          "domain_of": [
+            "AcquisitionMetadataMixin",
+            "MovieFrame",
+            "ProjectionImage"
+          ],
+          "range": "float"
+        },
+        "accumulated_dose": {
+          "name": "accumulated_dose",
+          "description": "The pre-exposure up to this image in e-/A^2",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "accumulated_dose",
+          "owner": "MovieFrame",
+          "domain_of": [
+            "AcquisitionMetadataMixin",
+            "MovieFrame",
+            "ProjectionImage"
+          ],
+          "range": "float"
+        },
+        "ctf_metadata": {
+          "name": "ctf_metadata",
+          "description": "A set of CTF patameters for an image.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "ctf_metadata",
+          "owner": "MovieFrame",
+          "domain_of": [
+            "AcquisitionMetadataMixin",
+            "MovieFrame",
+            "ProjectionImage"
+          ],
+          "range": "CTFMetadata"
+        },
+        "width": {
+          "name": "width",
+          "description": "The width of the image (x-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "width",
+          "owner": "MovieFrame",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "height": {
+          "name": "height",
+          "description": "The height of the image (y-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "height",
+          "owner": "MovieFrame",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "coordinate_systems": {
+          "name": "coordinate_systems",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_systems",
+          "owner": "MovieFrame",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateSystem",
+          "multivalued": true
+        },
+        "coordinate_transformations": {
+          "name": "coordinate_transformations",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_transformations",
+          "owner": "MovieFrame",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        }
+      }
+    },
+    "MovieStack": {
+      "name": "MovieStack",
+      "description": "A stack of movie frames.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "slots": [
+        "path",
+        "images_movie"
+      ],
+      "attributes": {
+        "path": {
+          "name": "path",
+          "description": "Path to a file.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "path",
+          "owner": "MovieStack",
+          "domain_of": [
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "MovieStack",
+            "ProjectionImage",
+            "TiltSeries",
+            "Tomogram",
+            "ParticleMap",
+            "Annotation",
+            "SubProjectionImage",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "string"
+        },
+        "images_movie": {
+          "name": "images_movie",
+          "description": "The movie frames in the stack",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "images_movie",
+          "owner": "MovieStack",
+          "domain_of": [
+            "MovieStack"
+          ],
+          "range": "MovieFrame",
+          "multivalued": true
+        }
+      }
+    },
+    "ProjectionImage": {
+      "name": "ProjectionImage",
+      "description": "A projection image.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "Image2D",
+      "mixins": [
+        "AcquisitionMetadataMixin"
+      ],
+      "slots": [
+        "path",
+        "section"
+      ],
+      "attributes": {
+        "path": {
+          "name": "path",
+          "description": "Path to a file.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "path",
+          "owner": "ProjectionImage",
+          "domain_of": [
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "MovieStack",
+            "ProjectionImage",
+            "TiltSeries",
+            "Tomogram",
+            "ParticleMap",
+            "Annotation",
+            "SubProjectionImage",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "string"
+        },
+        "section": {
+          "name": "section",
+          "description": "0-based section index to the entity inside a stack.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "section",
+          "owner": "ProjectionImage",
+          "domain_of": [
+            "MovieFrame",
+            "ProjectionImage"
+          ],
+          "range": "integer"
+        },
+        "nominal_tilt_angle": {
+          "name": "nominal_tilt_angle",
+          "description": "The tilt angle reported by the microscope",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "nominal_tilt_angle",
+          "owner": "ProjectionImage",
+          "domain_of": [
+            "AcquisitionMetadataMixin",
+            "MovieFrame",
+            "ProjectionImage"
+          ],
+          "range": "float"
+        },
+        "accumulated_dose": {
+          "name": "accumulated_dose",
+          "description": "The pre-exposure up to this image in e-/A^2",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "accumulated_dose",
+          "owner": "ProjectionImage",
+          "domain_of": [
+            "AcquisitionMetadataMixin",
+            "MovieFrame",
+            "ProjectionImage"
+          ],
+          "range": "float"
+        },
+        "ctf_metadata": {
+          "name": "ctf_metadata",
+          "description": "A set of CTF patameters for an image.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "ctf_metadata",
+          "owner": "ProjectionImage",
+          "domain_of": [
+            "AcquisitionMetadataMixin",
+            "MovieFrame",
+            "ProjectionImage"
+          ],
+          "range": "CTFMetadata"
+        },
+        "width": {
+          "name": "width",
+          "description": "The width of the image (x-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "width",
+          "owner": "ProjectionImage",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "height": {
+          "name": "height",
+          "description": "The height of the image (y-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "height",
+          "owner": "ProjectionImage",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "coordinate_systems": {
+          "name": "coordinate_systems",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_systems",
+          "owner": "ProjectionImage",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateSystem",
+          "multivalued": true
+        },
+        "coordinate_transformations": {
+          "name": "coordinate_transformations",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_transformations",
+          "owner": "ProjectionImage",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        }
+      }
+    },
+    "MovieStackSeries": {
+      "name": "MovieStackSeries",
+      "description": "A group of movie stacks that belong to a single tilt series.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "attributes": {
+        "stacks": {
+          "name": "stacks",
+          "description": "The movie stacks.",
+          "from_schema": "https://w3id.org/cetmd/image_entities",
+          "alias": "stacks",
+          "owner": "MovieStackSeries",
+          "domain_of": [
+            "MovieStackSeries"
+          ],
+          "range": "MovieStack",
+          "multivalued": true
+        }
+      }
+    },
+    "TiltSeries": {
+      "name": "TiltSeries",
+      "description": "A stack of projection images.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "slots": [
+        "images_tilt",
+        "path"
+      ],
+      "attributes": {
+        "images_tilt": {
+          "name": "images_tilt",
+          "description": "The projections in the stack",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "images_tilt",
+          "owner": "TiltSeries",
+          "domain_of": [
+            "TiltSeries"
+          ],
+          "range": "ProjectionImage",
+          "multivalued": true
+        },
+        "path": {
+          "name": "path",
+          "description": "Path to a file.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "path",
+          "owner": "TiltSeries",
+          "domain_of": [
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "MovieStack",
+            "ProjectionImage",
+            "TiltSeries",
+            "Tomogram",
+            "ParticleMap",
+            "Annotation",
+            "SubProjectionImage",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "SubProjectionImage": {
+      "name": "SubProjectionImage",
+      "description": "A croppecd projection image.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "ProjectionImage",
+      "slots": [
+        "particle_index"
+      ],
+      "attributes": {
+        "particle_index": {
+          "name": "particle_index",
+          "description": "Index of a particle inside a tomogram.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "particle_index",
+          "owner": "SubProjectionImage",
+          "domain_of": [
+            "SubProjectionImage"
+          ],
+          "range": "integer"
+        },
+        "path": {
+          "name": "path",
+          "description": "Path to a file.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "path",
+          "owner": "SubProjectionImage",
+          "domain_of": [
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "MovieStack",
+            "ProjectionImage",
+            "TiltSeries",
+            "Tomogram",
+            "ParticleMap",
+            "Annotation",
+            "SubProjectionImage",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "string"
+        },
+        "section": {
+          "name": "section",
+          "description": "0-based section index to the entity inside a stack.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "section",
+          "owner": "SubProjectionImage",
+          "domain_of": [
+            "MovieFrame",
+            "ProjectionImage"
+          ],
+          "range": "integer"
+        },
+        "nominal_tilt_angle": {
+          "name": "nominal_tilt_angle",
+          "description": "The tilt angle reported by the microscope",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "nominal_tilt_angle",
+          "owner": "SubProjectionImage",
+          "domain_of": [
+            "AcquisitionMetadataMixin",
+            "MovieFrame",
+            "ProjectionImage"
+          ],
+          "range": "float"
+        },
+        "accumulated_dose": {
+          "name": "accumulated_dose",
+          "description": "The pre-exposure up to this image in e-/A^2",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "accumulated_dose",
+          "owner": "SubProjectionImage",
+          "domain_of": [
+            "AcquisitionMetadataMixin",
+            "MovieFrame",
+            "ProjectionImage"
+          ],
+          "range": "float"
+        },
+        "ctf_metadata": {
+          "name": "ctf_metadata",
+          "description": "A set of CTF patameters for an image.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "ctf_metadata",
+          "owner": "SubProjectionImage",
+          "domain_of": [
+            "AcquisitionMetadataMixin",
+            "MovieFrame",
+            "ProjectionImage"
+          ],
+          "range": "CTFMetadata"
+        },
+        "width": {
+          "name": "width",
+          "description": "The width of the image (x-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "width",
+          "owner": "SubProjectionImage",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "height": {
+          "name": "height",
+          "description": "The height of the image (y-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "height",
+          "owner": "SubProjectionImage",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "coordinate_systems": {
+          "name": "coordinate_systems",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_systems",
+          "owner": "SubProjectionImage",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateSystem",
+          "multivalued": true
+        },
+        "coordinate_transformations": {
+          "name": "coordinate_transformations",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_transformations",
+          "owner": "SubProjectionImage",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        }
+      }
+    },
+    "Tomogram": {
+      "name": "Tomogram",
+      "description": "A 3D tomogram.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "Image3D",
+      "slots": [
+        "path"
+      ],
+      "attributes": {
+        "path": {
+          "name": "path",
+          "description": "Path to a file.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "path",
+          "owner": "Tomogram",
+          "domain_of": [
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "MovieStack",
+            "ProjectionImage",
+            "TiltSeries",
+            "Tomogram",
+            "ParticleMap",
+            "Annotation",
+            "SubProjectionImage",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "string"
+        },
+        "width": {
+          "name": "width",
+          "description": "The width of the image (x-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "width",
+          "owner": "Tomogram",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "height": {
+          "name": "height",
+          "description": "The height of the image (y-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "height",
+          "owner": "Tomogram",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "depth": {
+          "name": "depth",
+          "description": "The depth of the image (z-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "depth",
+          "owner": "Tomogram",
+          "domain_of": [
+            "Image3D",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask3D"
+          ],
+          "range": "integer"
+        },
+        "coordinate_systems": {
+          "name": "coordinate_systems",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_systems",
+          "owner": "Tomogram",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateSystem",
+          "multivalued": true
+        },
+        "coordinate_transformations": {
+          "name": "coordinate_transformations",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_transformations",
+          "owner": "Tomogram",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        }
+      }
+    },
+    "ParticleMap": {
+      "name": "ParticleMap",
+      "description": "A 3D particle density map.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "Image3D",
+      "slots": [
+        "path"
+      ],
+      "attributes": {
+        "path": {
+          "name": "path",
+          "description": "Path to a file.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "path",
+          "owner": "ParticleMap",
+          "domain_of": [
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "MovieStack",
+            "ProjectionImage",
+            "TiltSeries",
+            "Tomogram",
+            "ParticleMap",
+            "Annotation",
+            "SubProjectionImage",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "string"
+        },
+        "width": {
+          "name": "width",
+          "description": "The width of the image (x-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "width",
+          "owner": "ParticleMap",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "height": {
+          "name": "height",
+          "description": "The height of the image (y-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "height",
+          "owner": "ParticleMap",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "depth": {
+          "name": "depth",
+          "description": "The depth of the image (z-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "depth",
+          "owner": "ParticleMap",
+          "domain_of": [
+            "Image3D",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask3D"
+          ],
+          "range": "integer"
+        },
+        "coordinate_systems": {
+          "name": "coordinate_systems",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_systems",
+          "owner": "ParticleMap",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateSystem",
+          "multivalued": true
+        },
+        "coordinate_transformations": {
+          "name": "coordinate_transformations",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_transformations",
+          "owner": "ParticleMap",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        }
+      }
+    },
+    "CoordMetaMixin": {
+      "name": "CoordMetaMixin",
+      "description": "Coordinate system mixins for annotations.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "slots": [
+        "coordinate_systems",
+        "coordinate_transformations"
+      ],
+      "attributes": {
+        "coordinate_systems": {
+          "name": "coordinate_systems",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_systems",
+          "owner": "CoordMetaMixin",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateSystem",
+          "multivalued": true
+        },
+        "coordinate_transformations": {
+          "name": "coordinate_transformations",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_transformations",
+          "owner": "CoordMetaMixin",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        }
+      }
+    },
+    "Annotation": {
+      "name": "Annotation",
+      "description": "A primitive annotation.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "slots": [
+        "path"
+      ],
+      "attributes": {
+        "path": {
+          "name": "path",
+          "description": "Path to a file.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "path",
+          "owner": "Annotation",
+          "domain_of": [
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "MovieStack",
+            "ProjectionImage",
+            "TiltSeries",
+            "Tomogram",
+            "ParticleMap",
+            "Annotation",
+            "SubProjectionImage",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "SegmentationMask2D": {
+      "name": "SegmentationMask2D",
+      "description": "An annotation image with categorical labels.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "Annotation",
+      "mixins": [
+        "Image2D"
+      ],
+      "attributes": {
+        "width": {
+          "name": "width",
+          "description": "The width of the image (x-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "width",
+          "owner": "SegmentationMask2D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "height": {
+          "name": "height",
+          "description": "The height of the image (y-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "height",
+          "owner": "SegmentationMask2D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "coordinate_systems": {
+          "name": "coordinate_systems",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_systems",
+          "owner": "SegmentationMask2D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateSystem",
+          "multivalued": true
+        },
+        "coordinate_transformations": {
+          "name": "coordinate_transformations",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_transformations",
+          "owner": "SegmentationMask2D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        },
+        "path": {
+          "name": "path",
+          "description": "Path to a file.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "path",
+          "owner": "SegmentationMask2D",
+          "domain_of": [
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "MovieStack",
+            "ProjectionImage",
+            "TiltSeries",
+            "Tomogram",
+            "ParticleMap",
+            "Annotation",
+            "SubProjectionImage",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "SegmentationMask3D": {
+      "name": "SegmentationMask3D",
+      "description": "An annotation volume with categorical labels.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "Annotation",
+      "mixins": [
+        "Image3D"
+      ],
+      "attributes": {
+        "width": {
+          "name": "width",
+          "description": "The width of the image (x-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "width",
+          "owner": "SegmentationMask3D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "height": {
+          "name": "height",
+          "description": "The height of the image (y-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "height",
+          "owner": "SegmentationMask3D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "depth": {
+          "name": "depth",
+          "description": "The depth of the image (z-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "depth",
+          "owner": "SegmentationMask3D",
+          "domain_of": [
+            "Image3D",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask3D"
+          ],
+          "range": "integer"
+        },
+        "coordinate_systems": {
+          "name": "coordinate_systems",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_systems",
+          "owner": "SegmentationMask3D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateSystem",
+          "multivalued": true
+        },
+        "coordinate_transformations": {
+          "name": "coordinate_transformations",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_transformations",
+          "owner": "SegmentationMask3D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        },
+        "path": {
+          "name": "path",
+          "description": "Path to a file.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "path",
+          "owner": "SegmentationMask3D",
+          "domain_of": [
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "MovieStack",
+            "ProjectionImage",
+            "TiltSeries",
+            "Tomogram",
+            "ParticleMap",
+            "Annotation",
+            "SubProjectionImage",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "ProbabilityMap2D": {
+      "name": "ProbabilityMap2D",
+      "description": "An annotation image with real-valued labels.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "Annotation",
+      "mixins": [
+        "Image2D"
+      ],
+      "attributes": {
+        "width": {
+          "name": "width",
+          "description": "The width of the image (x-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "width",
+          "owner": "ProbabilityMap2D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "height": {
+          "name": "height",
+          "description": "The height of the image (y-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "height",
+          "owner": "ProbabilityMap2D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "coordinate_systems": {
+          "name": "coordinate_systems",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_systems",
+          "owner": "ProbabilityMap2D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateSystem",
+          "multivalued": true
+        },
+        "coordinate_transformations": {
+          "name": "coordinate_transformations",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_transformations",
+          "owner": "ProbabilityMap2D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        },
+        "path": {
+          "name": "path",
+          "description": "Path to a file.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "path",
+          "owner": "ProbabilityMap2D",
+          "domain_of": [
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "MovieStack",
+            "ProjectionImage",
+            "TiltSeries",
+            "Tomogram",
+            "ParticleMap",
+            "Annotation",
+            "SubProjectionImage",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "ProbabilityMap3D": {
+      "name": "ProbabilityMap3D",
+      "description": "An annotation volume with real-valued labels.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "Annotation",
+      "mixins": [
+        "Image3D"
+      ],
+      "attributes": {
+        "width": {
+          "name": "width",
+          "description": "The width of the image (x-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "width",
+          "owner": "ProbabilityMap3D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "height": {
+          "name": "height",
+          "description": "The height of the image (y-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "height",
+          "owner": "ProbabilityMap3D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D"
+          ],
+          "range": "integer"
+        },
+        "depth": {
+          "name": "depth",
+          "description": "The depth of the image (z-axis) in pixels",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "depth",
+          "owner": "ProbabilityMap3D",
+          "domain_of": [
+            "Image3D",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask3D"
+          ],
+          "range": "integer"
+        },
+        "coordinate_systems": {
+          "name": "coordinate_systems",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_systems",
+          "owner": "ProbabilityMap3D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateSystem",
+          "multivalued": true
+        },
+        "coordinate_transformations": {
+          "name": "coordinate_transformations",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_transformations",
+          "owner": "ProbabilityMap3D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        },
+        "path": {
+          "name": "path",
+          "description": "Path to a file.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "path",
+          "owner": "ProbabilityMap3D",
+          "domain_of": [
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "MovieStack",
+            "ProjectionImage",
+            "TiltSeries",
+            "Tomogram",
+            "ParticleMap",
+            "Annotation",
+            "SubProjectionImage",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "PointSet2D": {
+      "name": "PointSet2D",
+      "description": "A set of 2D point annotations.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "Annotation",
+      "mixins": [
+        "CoordMetaMixin"
+      ],
+      "slots": [
+        "origin2D"
+      ],
+      "attributes": {
+        "origin2D": {
+          "name": "origin2D",
+          "description": "Location on a 2D image (Nx2).",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "array": {
+            "exact_number_dimensions": 2,
+            "dimensions": [
+              {
+                "alias": "N",
+                "minimum_cardinality": 1
+              },
+              {
+                "alias": "xy",
+                "exact_cardinality": 2
+              }
+            ]
+          },
+          "alias": "origin2D",
+          "owner": "PointSet2D",
+          "domain_of": [
+            "PointSet2D",
+            "PointVectorSet2D",
+            "PointMatrixSet2D"
+          ],
+          "range": "float"
+        },
+        "coordinate_systems": {
+          "name": "coordinate_systems",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_systems",
+          "owner": "PointSet2D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateSystem",
+          "multivalued": true
+        },
+        "coordinate_transformations": {
+          "name": "coordinate_transformations",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_transformations",
+          "owner": "PointSet2D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        },
+        "path": {
+          "name": "path",
+          "description": "Path to a file.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "path",
+          "owner": "PointSet2D",
+          "domain_of": [
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "MovieStack",
+            "ProjectionImage",
+            "TiltSeries",
+            "Tomogram",
+            "ParticleMap",
+            "Annotation",
+            "SubProjectionImage",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "PointSet3D": {
+      "name": "PointSet3D",
+      "description": "A set of 3D point annotations.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "Annotation",
+      "mixins": [
+        "CoordMetaMixin"
+      ],
+      "slots": [
+        "origin3D"
+      ],
+      "attributes": {
+        "origin3D": {
+          "name": "origin3D",
+          "description": "Location on a 3D image (Nx3).",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "array": {
+            "exact_number_dimensions": 2,
+            "dimensions": [
+              {
+                "alias": "N",
+                "minimum_cardinality": 1
+              },
+              {
+                "alias": "xyz",
+                "exact_cardinality": 3
+              }
+            ]
+          },
+          "alias": "origin3D",
+          "owner": "PointSet3D",
+          "domain_of": [
+            "PointSet3D",
+            "PointVectorSet3D",
+            "PointMatrixSet3D"
+          ],
+          "range": "float"
+        },
+        "coordinate_systems": {
+          "name": "coordinate_systems",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_systems",
+          "owner": "PointSet3D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateSystem",
+          "multivalued": true
+        },
+        "coordinate_transformations": {
+          "name": "coordinate_transformations",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_transformations",
+          "owner": "PointSet3D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        },
+        "path": {
+          "name": "path",
+          "description": "Path to a file.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "path",
+          "owner": "PointSet3D",
+          "domain_of": [
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "MovieStack",
+            "ProjectionImage",
+            "TiltSeries",
+            "Tomogram",
+            "ParticleMap",
+            "Annotation",
+            "SubProjectionImage",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "PointVectorSet2D": {
+      "name": "PointVectorSet2D",
+      "description": "A set of 2D points with an associated direction vector.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "Annotation",
+      "mixins": [
+        "CoordMetaMixin"
+      ],
+      "slots": [
+        "origin2D",
+        "vector2D"
+      ],
+      "attributes": {
+        "origin2D": {
+          "name": "origin2D",
+          "description": "Location on a 2D image (Nx2).",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "array": {
+            "exact_number_dimensions": 2,
+            "dimensions": [
+              {
+                "alias": "N",
+                "minimum_cardinality": 1
+              },
+              {
+                "alias": "xy",
+                "exact_cardinality": 2
+              }
+            ]
+          },
+          "alias": "origin2D",
+          "owner": "PointVectorSet2D",
+          "domain_of": [
+            "PointSet2D",
+            "PointVectorSet2D",
+            "PointMatrixSet2D"
+          ],
+          "range": "float"
+        },
+        "vector2D": {
+          "name": "vector2D",
+          "description": "Orientation vector associated with a point on a 2D image (Nx2).",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "array": {
+            "exact_number_dimensions": 2,
+            "dimensions": [
+              {
+                "alias": "N",
+                "minimum_cardinality": 1
+              },
+              {
+                "alias": "xy",
+                "exact_cardinality": 2
+              }
+            ]
+          },
+          "alias": "vector2D",
+          "owner": "PointVectorSet2D",
+          "domain_of": [
+            "PointVectorSet2D"
+          ],
+          "range": "float"
+        },
+        "coordinate_systems": {
+          "name": "coordinate_systems",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_systems",
+          "owner": "PointVectorSet2D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateSystem",
+          "multivalued": true
+        },
+        "coordinate_transformations": {
+          "name": "coordinate_transformations",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_transformations",
+          "owner": "PointVectorSet2D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        },
+        "path": {
+          "name": "path",
+          "description": "Path to a file.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "path",
+          "owner": "PointVectorSet2D",
+          "domain_of": [
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "MovieStack",
+            "ProjectionImage",
+            "TiltSeries",
+            "Tomogram",
+            "ParticleMap",
+            "Annotation",
+            "SubProjectionImage",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "PointVectorSet3D": {
+      "name": "PointVectorSet3D",
+      "description": "A set of 3D points with an associated direction vector.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "Annotation",
+      "mixins": [
+        "CoordMetaMixin"
+      ],
+      "slots": [
+        "origin3D",
+        "vector3D"
+      ],
+      "attributes": {
+        "origin3D": {
+          "name": "origin3D",
+          "description": "Location on a 3D image (Nx3).",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "array": {
+            "exact_number_dimensions": 2,
+            "dimensions": [
+              {
+                "alias": "N",
+                "minimum_cardinality": 1
+              },
+              {
+                "alias": "xyz",
+                "exact_cardinality": 3
+              }
+            ]
+          },
+          "alias": "origin3D",
+          "owner": "PointVectorSet3D",
+          "domain_of": [
+            "PointSet3D",
+            "PointVectorSet3D",
+            "PointMatrixSet3D"
+          ],
+          "range": "float"
+        },
+        "vector3D": {
+          "name": "vector3D",
+          "description": "Orientation vector associated with a point on a 3D image (Nx3).",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "array": {
+            "exact_number_dimensions": 2,
+            "dimensions": [
+              {
+                "alias": "N",
+                "minimum_cardinality": 1
+              },
+              {
+                "alias": "xyz",
+                "exact_cardinality": 3
+              }
+            ]
+          },
+          "alias": "vector3D",
+          "owner": "PointVectorSet3D",
+          "domain_of": [
+            "PointVectorSet3D"
+          ],
+          "range": "float"
+        },
+        "coordinate_systems": {
+          "name": "coordinate_systems",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_systems",
+          "owner": "PointVectorSet3D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateSystem",
+          "multivalued": true
+        },
+        "coordinate_transformations": {
+          "name": "coordinate_transformations",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_transformations",
+          "owner": "PointVectorSet3D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        },
+        "path": {
+          "name": "path",
+          "description": "Path to a file.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "path",
+          "owner": "PointVectorSet3D",
+          "domain_of": [
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "MovieStack",
+            "ProjectionImage",
+            "TiltSeries",
+            "Tomogram",
+            "ParticleMap",
+            "Annotation",
+            "SubProjectionImage",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "PointMatrixSet2D": {
+      "name": "PointMatrixSet2D",
+      "description": "A set of 2D points with an associated rotation matrix.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "Annotation",
+      "mixins": [
+        "CoordMetaMixin"
+      ],
+      "slots": [
+        "origin2D",
+        "matrix2D"
+      ],
+      "attributes": {
+        "origin2D": {
+          "name": "origin2D",
+          "description": "Location on a 2D image (Nx2).",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "array": {
+            "exact_number_dimensions": 2,
+            "dimensions": [
+              {
+                "alias": "N",
+                "minimum_cardinality": 1
+              },
+              {
+                "alias": "xy",
+                "exact_cardinality": 2
+              }
+            ]
+          },
+          "alias": "origin2D",
+          "owner": "PointMatrixSet2D",
+          "domain_of": [
+            "PointSet2D",
+            "PointVectorSet2D",
+            "PointMatrixSet2D"
+          ],
+          "range": "float"
+        },
+        "matrix2D": {
+          "name": "matrix2D",
+          "description": "Rotation matrix associated with a point on a 2D image (Nx2x2).",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "array": {
+            "exact_number_dimensions": 3,
+            "dimensions": [
+              {
+                "alias": "N",
+                "minimum_cardinality": 1
+              },
+              {
+                "alias": "xy",
+                "exact_cardinality": 2
+              },
+              {
+                "alias": "xy",
+                "exact_cardinality": 2
+              }
+            ]
+          },
+          "alias": "matrix2D",
+          "owner": "PointMatrixSet2D",
+          "domain_of": [
+            "PointMatrixSet2D"
+          ],
+          "range": "float"
+        },
+        "coordinate_systems": {
+          "name": "coordinate_systems",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_systems",
+          "owner": "PointMatrixSet2D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateSystem",
+          "multivalued": true
+        },
+        "coordinate_transformations": {
+          "name": "coordinate_transformations",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_transformations",
+          "owner": "PointMatrixSet2D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        },
+        "path": {
+          "name": "path",
+          "description": "Path to a file.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "path",
+          "owner": "PointMatrixSet2D",
+          "domain_of": [
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "MovieStack",
+            "ProjectionImage",
+            "TiltSeries",
+            "Tomogram",
+            "ParticleMap",
+            "Annotation",
+            "SubProjectionImage",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "PointMatrixSet3D": {
+      "name": "PointMatrixSet3D",
+      "description": "A set of 3D points with an associated rotation matrix.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "Annotation",
+      "mixins": [
+        "CoordMetaMixin"
+      ],
+      "slots": [
+        "origin3D",
+        "matrix3D"
+      ],
+      "attributes": {
+        "origin3D": {
+          "name": "origin3D",
+          "description": "Location on a 3D image (Nx3).",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "array": {
+            "exact_number_dimensions": 2,
+            "dimensions": [
+              {
+                "alias": "N",
+                "minimum_cardinality": 1
+              },
+              {
+                "alias": "xyz",
+                "exact_cardinality": 3
+              }
+            ]
+          },
+          "alias": "origin3D",
+          "owner": "PointMatrixSet3D",
+          "domain_of": [
+            "PointSet3D",
+            "PointVectorSet3D",
+            "PointMatrixSet3D"
+          ],
+          "range": "float"
+        },
+        "matrix3D": {
+          "name": "matrix3D",
+          "description": "Rotation matrix associated with a point on a 3D image (Nx3x3).",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "array": {
+            "exact_number_dimensions": 3,
+            "dimensions": [
+              {
+                "alias": "N",
+                "minimum_cardinality": 1
+              },
+              {
+                "alias": "xyz",
+                "exact_cardinality": 3
+              },
+              {
+                "alias": "xyz",
+                "exact_cardinality": 3
+              }
+            ]
+          },
+          "alias": "matrix3D",
+          "owner": "PointMatrixSet3D",
+          "domain_of": [
+            "PointMatrixSet3D"
+          ],
+          "range": "float"
+        },
+        "coordinate_systems": {
+          "name": "coordinate_systems",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_systems",
+          "owner": "PointMatrixSet3D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateSystem",
+          "multivalued": true
+        },
+        "coordinate_transformations": {
+          "name": "coordinate_transformations",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_transformations",
+          "owner": "PointMatrixSet3D",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        },
+        "path": {
+          "name": "path",
+          "description": "Path to a file.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "path",
+          "owner": "PointMatrixSet3D",
+          "domain_of": [
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "MovieStack",
+            "ProjectionImage",
+            "TiltSeries",
+            "Tomogram",
+            "ParticleMap",
+            "Annotation",
+            "SubProjectionImage",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "TriMesh": {
+      "name": "TriMesh",
+      "description": "A mesh annotation.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "Annotation",
+      "mixins": [
+        "CoordMetaMixin"
+      ],
+      "attributes": {
+        "coordinate_systems": {
+          "name": "coordinate_systems",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_systems",
+          "owner": "TriMesh",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateSystem",
+          "multivalued": true
+        },
+        "coordinate_transformations": {
+          "name": "coordinate_transformations",
+          "description": "Named coordinate systems for this entity",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "coordinate_transformations",
+          "owner": "TriMesh",
+          "domain_of": [
+            "Image2D",
+            "Image3D",
+            "CoordMetaMixin",
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "ProjectionImage",
+            "SubProjectionImage",
+            "Tomogram",
+            "ParticleMap",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true
+        },
+        "path": {
+          "name": "path",
+          "description": "Path to a file.",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "alias": "path",
+          "owner": "TriMesh",
+          "domain_of": [
+            "GainFile",
+            "DefectFile",
+            "MovieFrame",
+            "MovieStack",
+            "ProjectionImage",
+            "TiltSeries",
+            "Tomogram",
+            "ParticleMap",
+            "Annotation",
+            "SubProjectionImage",
+            "SegmentationMask2D",
+            "SegmentationMask3D",
+            "ProbabilityMap2D",
+            "ProbabilityMap3D",
+            "PointSet2D",
+            "PointSet3D",
+            "PointVectorSet2D",
+            "PointVectorSet3D",
+            "PointMatrixSet2D",
+            "PointMatrixSet3D"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "ProjectionAlignment": {
+      "name": "ProjectionAlignment",
+      "description": "The tomographic alignment for a single projection.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "is_a": "Sequence",
+      "attributes": {
+        "input": {
+          "name": "input",
+          "description": "The source coordinate system name",
+          "from_schema": "https://w3id.org/cetmd/alignment/",
+          "alias": "input",
+          "owner": "ProjectionAlignment",
+          "domain_of": [
+            "CoordinateTransformation",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine",
+            "Sequence",
+            "ProjectionAlignment"
+          ],
+          "range": "string"
+        },
+        "output": {
+          "name": "output",
+          "description": "The target coordinate system name",
+          "from_schema": "https://w3id.org/cetmd/alignment/",
+          "alias": "output",
+          "owner": "ProjectionAlignment",
+          "domain_of": [
+            "CoordinateTransformation",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine",
+            "Sequence",
+            "ProjectionAlignment"
+          ],
+          "range": "string"
+        },
+        "sequence": {
+          "name": "sequence",
+          "description": "The sequence of transformations",
+          "from_schema": "https://w3id.org/cetmd/alignment/",
+          "alias": "sequence",
+          "owner": "ProjectionAlignment",
+          "domain_of": [
+            "Sequence",
+            "ProjectionAlignment"
+          ],
+          "range": "CoordinateTransformation",
+          "multivalued": true,
+          "maximum_cardinality": 2,
+          "any_of": [
+            {
+              "range": "Affine"
+            },
+            {
+              "range": "Translation"
+            }
+          ]
+        },
+        "transformation_type": {
+          "name": "transformation_type",
+          "description": "The type of transformation",
+          "from_schema": "https://w3id.org/cetmd/entities",
+          "ifabsent": "sequence",
+          "alias": "transformation_type",
+          "owner": "ProjectionAlignment",
+          "domain_of": [
+            "CoordinateTransformation",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine",
+            "Sequence"
+          ],
+          "range": "TransformationType"
+        },
+        "name": {
+          "name": "name",
+          "description": "The name of the coordinate transformation",
+          "from_schema": "https://w3id.org/cetmd/coord_transforms",
+          "alias": "name",
+          "owner": "ProjectionAlignment",
+          "domain_of": [
+            "Average",
+            "Dataset",
+            "CoordinateSystem",
+            "CoordinateTransformation",
+            "Identity",
+            "MapAxis",
+            "Translation",
+            "Scale",
+            "Affine",
+            "Sequence"
+          ],
+          "range": "string"
+        }
+      }
+    },
+    "Alignment": {
+      "name": "Alignment",
+      "description": "The tomographic alignment for a tilt series.",
+      "from_schema": "https://w3id.org/cetmd/entities",
+      "attributes": {
+        "projection_alignments": {
+          "name": "projection_alignments",
+          "description": "alignment for a specific projection",
+          "from_schema": "https://w3id.org/cetmd/alignment/",
+          "alias": "projection_alignments",
+          "owner": "Alignment",
+          "domain_of": [
+            "Alignment"
+          ],
+          "range": "ProjectionAlignment",
+          "multivalued": true
+        }
+      }
+    }
+  },
+  "source_file": "schema/linkml/entities.yaml",
+  "@type": "SchemaDefinition"
+}

--- a/schema/linkml/acquisition.yaml
+++ b/schema/linkml/acquisition.yaml
@@ -1,0 +1,230 @@
+id: https://w3id.org/osc-em/acquisition
+name: OSCEMAcquisiton
+description: >
+  LinkML schema for electron microscopy sample and author-related metadata,
+  broadly following the EMDB standard with some additions.
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  acquisition: https://w3id.org/osc-em/acquisition
+  types: https://w3id.org/osc-em/custom_types
+
+default_prefix: acquisition
+
+imports:
+  - linkml:types
+  - ./custom_types
+
+classes:
+  Acquisition:
+    description: A set of parameteres describing the data acquisition
+    slots:
+    - nominal_defocus
+    - calibrated_defocus
+    - nominal_magnification
+    - calibrated_magnification
+    - holder
+    - holder_cryogen
+    - temperature_range
+    - microscope_software
+    - detector
+    - detector_mode
+    - dose_per_movie
+    - energy_filter
+    - image_size
+    - date_time
+    - exposure_time
+    - cryogen
+    - frames_per_movie
+    - grids_imaged
+    - images_generated
+    - binning_camera
+    - pixel_size
+    - specialist_optics
+    - beamshift
+    - beamtilt
+    - imageshift
+    - beamtiltgroups
+    - gainref_flip_rotate
+    slot_usage:
+      detector:
+        required: true
+      dose_per_movie:
+        required: true
+      date_time:
+        required: true
+      binning_camera:
+        required: true
+      pixel_size:
+        required: true
+
+  EnergyFilter:
+    description: A device used to filter for electrons with specific energy.
+    slots:
+    - used
+    - model
+    - width_energy_filter
+    slot_usage:
+      used:
+        required: true
+      width_energy_filter:
+        required: true
+
+  SpecialistOptics:
+    description: Optional optics used to correct for instrument limitations.
+    slots:
+    - phaseplate
+    - spherical_aberration_corrector
+    - chromatic_aberration_corrector
+  Phaseplate:
+    description: Used to modulate the phase of the electron wave.
+    slots:
+    - used
+    - instrument_type
+    slot_usage:
+      used:
+        required: true
+      instrument_type:
+        description: Type of phaseplate
+        required: true
+  SphericalAberrationCorrector:
+    description: Special device used to correct instrument inherent spherical aberration.
+    slots:
+    - used
+    - instrument_type
+    slot_usage:
+      used:
+        required: true
+      instrument_type:
+        required: true
+  ChromaticAberrationCorrector:
+    description: Special device used to correct instrument inherent chromatic aberration.
+    slots:
+    - used
+    - instrument_type
+    slot_usage:
+      used:
+        required: true
+      instrument_type:
+        required: true
+
+slots:
+  nominal_defocus:
+    range: Range
+    description: Target defocus set, min and max values in µm.
+  calibrated_defocus:
+    range: Range
+    description: Machine estimated defocus, min and max values in µm. Has a tendency to be off.
+  nominal_magnification:
+    description: Magnification level as indicated by the instrument, no unit
+    range: integer
+  calibrated_magnification:
+    description: Calculated magnification, no unit
+    range: integer
+  holder:
+    description: Speciman holder model
+    range: string
+  holder_cryogen:
+    description: Type of cryogen used in the holder - if the holder is cooled seperately
+    range: string
+  temperature_range:
+    range: Range
+    description: Temperature during data collection, in K with min and max values.
+    alias: temperature
+  microscope_software:
+    description: Software used for instrument control,
+    range: string
+  detector:
+    description: Make and model of the detector used
+    range: string
+  detector_mode:
+    description: Operating mode of the detector
+    range: string
+  dose_per_movie:
+    description: Average dose per image/movie/tilt - given in electrons per square Angstrom
+    range: Any
+    any_of:
+      - range:  QuantityValue
+      - range:  QuantitySI
+  energy_filter:
+    range: EnergyFilter
+    description: Wether an energy filter was used and its specifics.
+  used:
+    description: whether a specific instrument was used during data acquisition
+    range: boolean
+  model:
+    description: Make and model of a specilized device
+    range: string
+  image_size:
+    range: ImageSize
+    description: The size of the image in pixels, height and width given.
+  date_time:
+    description: Time and date of the data acquisition
+    # range is required
+    range: datetime
+    #any_of:
+     # - range: datetime
+     #- range: date
+  exposure_time:
+    description: Time of data acquisition per movie/tilt - in s
+    range: Any
+    any_of:
+      - range:  QuantityValue
+      - range:  QuantitySI
+  cryogen:
+    description: Cryogen used in cooling the instrument and sample, usually nitrogen
+    range: string
+  frames_per_movie:
+    description: Number of frames that on average constitute a full movie, can be a bit hard to define for some detectors
+    range: integer
+  grids_imaged:
+    description: Number of grids imaged for this project - here with qualifier during this data acquisition
+    range: integer
+  images_generated:
+    description: Number of images generated total for this data collection - might need a qualifier for tilt series to determine whether full series or individual tilts are counted
+    range: integer
+  binning_camera:
+    description: Level of binning on the images applied during data collection
+    range: float
+  pixel_size:
+    description: Pixel size, in Angstrom
+    range: Any
+    any_of:
+      - range:  QuantityValue
+      - range:  QuantitySI
+  specialist_optics:
+    description: Any type of special optics, such as a phaseplate
+    range: SpecialistOptics
+  phaseplate:
+    description: Phaseplate is a special optics device that can be used to enhance contrast
+    range: Phaseplate
+  instrument_type:
+    description: Details of a given specialist instrument
+    range: string
+  spherical_aberration_corrector:
+    range: SphericalAberrationCorrector
+    description: Specialist device to correct for spherical aberration of the microscope lenses
+  chromatic_aberration_corrector:
+    range: ChromaticAberrationCorrector
+    description: Specialist device to correct for chromatic aberration of the microscope lenses
+  beamshift:
+    range: BoundingBox2D
+    description: Movement of the beam above the sample for data collection purposes that does not require movement of the stage. Given in mrad.
+  beamtilt:
+    range: BoundingBox2D
+    description: Another way to move the beam above the sample for data collection purposes that does not require movement of the stage. Given in mrad.
+  imageshift:
+    range: BoundingBox2D
+    description: Movement of the Beam below the image in order to shift the image on the detector. Given in µm.
+  beamtiltgroups:
+    range: integer
+    description: Number of Beamtilt groups present in this dataset - for optimized processing split dataset into groups of same tilt angle. Despite its name Beamshift is often used to achive this result.
+  gainref_flip_rotate:
+    range: string
+    description: Whether and how you have to flip or rotate the gainref in order to align with your acquired images
+  width_energy_filter:
+    range: Any
+    any_of:
+      - range:  QuantityValue
+      - range:  QuantitySI
+    description: Width of the energy filter used.

--- a/schema/linkml/alignment.yaml
+++ b/schema/linkml/alignment.yaml
@@ -1,5 +1,5 @@
-name: CETMDAlignment
-id: CETMDAlignment
+name: alignment
+id: https://w3id.org/cetmd/alignment/
 version: 0.0.1
 description: Schema for cryoET alignments
 prefixes:

--- a/schema/linkml/annotation.yaml
+++ b/schema/linkml/annotation.yaml
@@ -1,4 +1,4 @@
-name: CETMDAnnotation
+name: annotation
 id: https://w3id.org/cetmd/annotation
 version: 0.0.1
 description: Schema for cryoET alignments

--- a/schema/linkml/annotation.yaml
+++ b/schema/linkml/annotation.yaml
@@ -5,7 +5,7 @@ description: Schema for cryoET alignments
 prefixes:
   linkml: https://w3id.org/linkml/
   image: https://w3id.org/cetmd/image/
-  annotations: https://w3id.org/cetmd/annotation/
+  annotation: https://w3id.org/cetmd/annotation/
 
 default_prefix: annotation
 

--- a/schema/linkml/coordinate_systems.yaml
+++ b/schema/linkml/coordinate_systems.yaml
@@ -1,4 +1,4 @@
-name: CETMDCoordinateSystems
+name: coordinate_systems
 id: https://w3id.org/cetmd/coordinate_systems
 version: 0.0.1
 description: Schema for cryoET alignments
@@ -25,17 +25,21 @@ slots:
 classes:
   Axis:
     description: An axis in a coordinate system
-    attributes:
-      name:
-        exact_mappings:
-          - axis_name
-        required: true
-      axis_unit:
-        exact_mappings:
-          - axis_unit
-      axis_type:
-        exact_mappings:
-          - axis_type
+    slots:
+    - axis_name
+    - axis_unit
+    - axis_type
+#     attributes:
+#       axis_name:
+#  #       exact_mappings:
+#  #         - axis_name
+#         required: true
+#       axis_unit:
+#  #       exact_mappings:
+#  #         - axis_unit
+#       axis_type:
+#  #       exact_mappings:
+#  #         - axis_type
 
   CoordinateSystem:
     description: A coordinate system

--- a/schema/linkml/coordinate_systems.yaml
+++ b/schema/linkml/coordinate_systems.yaml
@@ -2,11 +2,13 @@ name: coordinate_systems
 id: https://w3id.org/cetmd/coordinate_systems
 version: 0.0.1
 description: Schema for cryoET alignments
-imports:
-- linkml:types
+
 prefixes:
   linkml: https://w3id.org/linkml/
   coordinate_systems: https://w3id.org/cetmd/coordinate_systems/
+
+imports:
+- linkml:types
 
 default_prefix: coordinate_systems
 
@@ -29,6 +31,9 @@ classes:
     - axis_name
     - axis_unit
     - axis_type
+    slot_usage:
+      axis_name:
+        required: true
 #     attributes:
 #       axis_name:
 #  #       exact_mappings:

--- a/schema/linkml/coordinate_transforms.yaml
+++ b/schema/linkml/coordinate_transforms.yaml
@@ -1,4 +1,4 @@
-name: CETMDCoordTransforms
+name: coordinate_transforms
 id: https://w3id.org/cetmd/coord_transforms
 version: 0.0.1
 description: Schema for cryoET alignments
@@ -15,6 +15,8 @@ imports:
 classes:
   CoordinateTransformation:
     description: A coordinate transformation
+    slots:
+    - transformation_type
     attributes:
       name:
         description: The name of the coordinate transformation
@@ -25,19 +27,17 @@ classes:
       output:
         description: The target coordinate system name
         range: string
-      type:
-        description: The type of transformation
-        range: TransformationType
 
 
   Identity:
     description: The identity transformation
     is_a: CoordinateTransformation
-    attributes:
-      type:
-        description: The type of transformation
-        range: TransformationType
+    slots:
+    - transformation_type
+    slot_usage:
+      transformation_type:
         ifabsent: identity
+
 
 
   AxisNameMapping:
@@ -54,25 +54,28 @@ classes:
   MapAxis:
     description: Axis permutation transformation
     is_a: CoordinateTransformation
+    slots:
+    - transformation_type
+    slot_usage:
+      transformation_type:
+        ifabsent: map_axis
     attributes:
-      type:
-        description: The type of transformation
-        range: TransformationType
-        ifabsent: mapAxis
-      mapAxis:
+      map_axis:
         description: The permutation of the axes
         range: AxisNameMapping
         inlined: true
         multivalued: true
 
+
   Translation:
     description: A translation transformation
     is_a: CoordinateTransformation
-    attributes:
-      type:
-        description: The type of transformation
-        range: TransformationType
+    slots:
+    - transformation_type
+    slot_usage:
+      transformation_type:
         ifabsent: translation
+    attributes:
       translation:
         description: The translation vector
         range: float
@@ -81,11 +84,12 @@ classes:
   Scale:
     description: A scaling transformation
     is_a: CoordinateTransformation
-    attributes:
-      type:
-        description: The type of transformation
-        range: TransformationType
+    slots:
+    - transformation_type
+    slot_usage:
+      transformation_type:
         ifabsent: scale
+    attributes:
       scale:
         description: The scaling vector
         range: float
@@ -94,11 +98,12 @@ classes:
   Affine:
     description: An affine transformation
     is_a: CoordinateTransformation
-    attributes:
-      type:
-        description: The type of transformation
-        range: TransformationType
+    slots:
+    - transformation_type
+    slot_usage:
+      transformation_type:
         ifabsent: affine
+    attributes:
       affine:
         description: The affine matrix
         range: integer
@@ -113,11 +118,12 @@ classes:
   Sequence:
     description: A sequence of transformations
     is_a: CoordinateTransformation
-    attributes:
-      type:
-        description: The type of transformation
-        range: TransformationType
+    slots:
+    - transformation_type
+    slot_usage:
+      transformation_type:
         ifabsent: sequence
+    attributes:
       sequence:
         description: The sequence of transformations
         range: CoordinateTransformation
@@ -128,7 +134,7 @@ enums:
     permissible_values:
       identity:
         description: The identity transformation.
-      mapAxis:
+      map_axis:
         description: Axis permutation transformation
       translation:
         description: A translation transformation.
@@ -138,3 +144,8 @@ enums:
         description: An affine transformation
       sequence:
         description: A sequence of transformations
+
+slots:
+  transformation_type:
+    description: The type of transformation
+    range: TransformationType

--- a/schema/linkml/custom_types.yaml
+++ b/schema/linkml/custom_types.yaml
@@ -1,0 +1,179 @@
+id: https://w3id.org/osc-em/custom_types
+name: custom_types
+description: Mixins for basic types shared among OSC-EM schemas
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  custom_types: https://w3id.org/osc-em/custom_types
+
+default_prefix: custom_types
+
+imports:
+  - linkml:types
+
+
+classes:
+  Any:
+    description: Any type, used as the base for type-narrowing.
+    class_uri: linkml:Any
+  Range:
+    description: A range constructed from min and max
+    slots:
+    - minimal
+    - maximal
+  #RangeSI:
+  #  description: A range constructed from min and max, si units attached
+   # slots:
+  #  - minimal_si
+  #  - maximal_si
+  Series:
+    is_a: Range
+    description: A series of numbers constructed from min, max, and increment
+    slots:
+    - increment
+  ImageSize:
+    description: size of a 2D image (in integer units)
+    slots:
+    - height_im
+    - width_im
+  BoundingBox2D:
+    description: an axis-aligned 2D bounding box (float units)
+    slots:
+    - x_min
+    - x_max
+    - y_min
+    - y_max
+  #BoundingBox2DSI:
+   # description: an axis-aligned 2D bounding box (float units) with SI unit attached
+    #slots:
+  #  - x_min_si
+  #  - x_max_si
+  #  - y_min_si
+   # - y_max_si
+  QuantityValue:
+    class_uri: qudt:quantityValue
+    description: if a value has a unit, it should be given as a unit value pair.
+    slots:
+    - unit
+    - value
+    slot_usage:
+      unit:
+        required: true
+      value:
+        required: true
+  QuantitySI:
+    is_a: QuantityValue
+    description: unit value extended to have two additional fields si_value and si_unit
+    slots:
+    - valueSI
+    - unitSI
+    slot_usage:
+      si_value:
+        required: true
+      si_unit:
+        required: true
+  Descriptor:
+    description: List of custom descriptors for user-defined key-value pairs describing how micrographs were obtained or any related information
+    abstract: true
+    slots:
+    - descriptor_name
+    - descriptor_thing
+    slot_usage:
+      descriptor_name:
+        required: true
+      descriptor_thing:
+        required: false
+  Descriptors:
+    is_a: Descriptor
+
+slots:
+  minimal:
+    description: Minimal value of a given dataset property
+    range: Any
+    any_of:
+      - range:  QuantityValue
+      - range:  QuantitySI
+  maximal:
+    description: Maximal value of a given dataset property
+    range: Any
+    any_of:
+      - range:  QuantityValue
+      - range:  QuantitySI
+  increment:
+    description: Increment between elements of a series
+    range: Any
+    any_of:
+      - range:  QuantityValue
+      - range:  QuantitySI
+  width_im:
+    description: The width of a given item - unit depends on item
+    range: integer
+  height_im:
+    description: The height of a given item - unit depends on item
+    range: integer
+  x_min:
+    description: minimum x
+    range: Any
+    any_of:
+      - range:  QuantityValue
+      - range:  QuantitySI
+  x_max:
+    description: maximum x
+    range: Any
+    any_of:
+      - range:  QuantityValue
+      - range:  QuantitySI
+  y_min:
+    description: minimum y
+    range: Any
+    any_of:
+      - range:  QuantityValue
+      - range:  QuantitySI
+  y_max:
+    description: maximum y
+    range: Any
+    any_of:
+      - range:  QuantityValue
+      - range:  QuantitySI
+  unit:
+    description: the unit of a given value
+    range: string
+    slot_uri: qudt:hasUnit
+  value:
+    description: the value of a field with a unit
+    range: float
+    slot_uri: qudt:hasQuantityKind
+  descriptors:
+    description: List of custom descriptors for user-defined key-value pairs describing how movies were obtained or any related information
+    range: Descriptors
+    multivalued: true
+  descriptor_name:
+    description: Name defining the descriptor
+    range: string
+  descriptor_thing:
+    description: Description of the descriptor
+    range: Any
+  valueSI:
+    description: value of a given field in respect to its SI unit
+    range: float
+  unitSI:
+    description: the SI unit attached to a si value
+    range: string
+ # minimal_si:
+  #  description: Minimal value of a given dataset property, with si units
+  #  range: QuantitySI
+  #maximal_si:
+  #  description: Maximal value of a given dataset property, with si units
+  #  range: QuantitySI
+  #x_min_si:
+  #  description: minimum x, with si units
+  #  range: QuantitySI
+  #x_max_si:
+  #  description: maximum x, with si units
+  #  range: QuantitySI
+  #y_min_si:
+  #  description: minimum y, with si units
+  #  range: QuantitySI
+  #y_max_si:
+  #  description: maximum y, with si units
+  #  range: QuantitySI

--- a/schema/linkml/entities.yaml
+++ b/schema/linkml/entities.yaml
@@ -6,10 +6,11 @@ description: Schema for cryoET geometry
 prefixes:
   linkml: https://w3id.org/linkml/
   image_entities: https://w3id.org/cetmd/image_entities/
-  entities: https://w3id.org/cetmd/entities/
+#  entities: https://w3id.org/cetmd/entities/
   annotation: https://w3id.org/cetmd/annotation/
 
-default_prefix: entities
+
+#default_prefix: entities
 
 imports:
 - linkml:types

--- a/schema/linkml/entities.yaml
+++ b/schema/linkml/entities.yaml
@@ -15,7 +15,6 @@ imports:
 - linkml:types
 - ./image_entities
 - ./annotation
-
 - ./alignment
 
 classes:

--- a/schema/linkml/entities.yaml
+++ b/schema/linkml/entities.yaml
@@ -1,11 +1,11 @@
-name: CETMDEntities
+name: entities
 id: https://w3id.org/cetmd/entities
 version: 0.0.1
 description: Schema for cryoET geometry
 
 prefixes:
   linkml: https://w3id.org/linkml/
-  image_entities: https://w3id.org/cetmd/imageentities/
+  image_entities: https://w3id.org/cetmd/image_entities/
   entities: https://w3id.org/cetmd/entities/
   annotation: https://w3id.org/cetmd/annotation/
 
@@ -16,10 +16,14 @@ imports:
 - ./image_entities
 - ./annotation
 
+- ./alignment
+
 classes:
   Region:
     description: Raw data (movie stacks) and derived data (tilt series, tomograms, annotations) from a single region of
       a specimen.
+    slots:
+    - annotations
     attributes:
       movie_stack_collections:
         description: The movie stack
@@ -37,25 +41,18 @@ classes:
         description: The tomograms
         range: Tomogram
         multivalued: true
-      annotations:
-        description: The annotations for this region
-        range: Annotation
-        multivalued: true
 
   Average:
     description: A particle averaging experiment.
+    slots:
+    - name
+    - annotations
     attributes:
-      name:
-        description: The name of the averaging experiment.
-        range: string
       particle_maps:
         description: The particle maps
         range: ParticleMap
         multivalued: true
-      annotations:
-        description: The annotations
-        range: Annotation
-        multivalued: true
+
 
   MovieStackCollection:
     description: A collection of movie stacks using the same gain and defect files.
@@ -64,19 +61,18 @@ classes:
         description: The movie stacks in the collection
         range: MovieStackSeries
         multivalued: true
-      GainFile:
+      gain_file:
         description: The gain file for the movie stacks
         range: GainFile
-      DefectFile:
+      defect_file:
         description: The defect file for the movie stacks
         range: DefectFile
 
   Dataset:
     description: A dataset
+    slots:
+    - name
     attributes:
-      name:
-        description: The name of the dataset
-        range: string
       regions:
         description: The regions in the dataset
         range: Region
@@ -85,3 +81,12 @@ classes:
         description: The averages in the dataset
         range: Average
         multivalued: true
+
+slots:
+  name:
+    description: The name of a given entry
+    range: string
+  annotations:
+    description: The annotations
+    range: Annotation
+    multivalued: true

--- a/schema/linkml/entities.yaml
+++ b/schema/linkml/entities.yaml
@@ -5,9 +5,9 @@ description: Schema for cryoET geometry
 
 prefixes:
   linkml: https://w3id.org/linkml/
-  image_entities: https://w3id.org/cetmd/image_entities/
+#  image_entities: https://w3id.org/cetmd/image_entities/
 #  entities: https://w3id.org/cetmd/entities/
-  annotation: https://w3id.org/cetmd/annotation/
+#  annotation: https://w3id.org/cetmd/annotation/
 
 
 #default_prefix: entities
@@ -17,6 +17,10 @@ imports:
 - ./image_entities
 - ./annotation
 - ./alignment
+- ./acquisition
+- ./custom_types
+- ./instrument
+- ./tomography
 
 classes:
   Region:
@@ -81,6 +85,17 @@ classes:
         description: The averages in the dataset
         range: Average
         multivalued: true
+
+  DataAcquisition:
+    description: information about the instrument and the data collection itself
+    attributes:
+      instrument:
+        range: Instrument
+        description: Contains information regarding instrument constants
+      acquisition:
+        range: AcquisitionTomo
+        description: Contains details on data collection parameters
+    
 
 slots:
   name:

--- a/schema/linkml/image.yaml
+++ b/schema/linkml/image.yaml
@@ -1,4 +1,4 @@
-name: CETMDImage
+name: image
 id: https://w3id.org/cetmd/image/
 version: 0.0.1
 description: Schema for cryoET alignments
@@ -6,7 +6,7 @@ prefixes:
   linkml: https://w3id.org/linkml/
   image: https://w3id.org/cetmd/image/
 
-default_prefix: image
+#default_prefix: image
 
 imports:
 - linkml:types
@@ -30,6 +30,14 @@ slots:
     description: Named coordinate systems for this entity
     range: CoordinateTransformation
     multivalued: true
+  images2D:
+    description: The images in the stack
+    range: Image2D
+    multivalued: true
+  images3D:
+    description: The images in the stack
+    range: Image3D
+    multivalued: true
 
 classes:
   Image2D:
@@ -51,17 +59,11 @@ classes:
 
   ImageStack2D:
     description: A stack of 2D images.
-    attributes:
-      images:
-        description: The images in the stack
-        range: Image2D
-        multivalued: true
+    slots:
+    - images2D
 
   ImageStack3D:
     description: A stack of 3D images.
-    attributes:
-      images:
-        description: The images in the stack
-        range: Image3D
-        multivalued: true
+    slots:
+    - images3D
 

--- a/schema/linkml/image_entities.yaml
+++ b/schema/linkml/image_entities.yaml
@@ -1,11 +1,12 @@
-name: CETMDImageEntities
-id: https://w3id.org/cetmd/imageentities
+name: image_entities
+id: https://w3id.org/cetmd/image_entities
 version: 0.0.1
 description: Schema for cryoET alignments
 
 prefixes:
   linkml: https://w3id.org/linkml/
-  image_entities: https://w3id.org/cetmd/imageentities/
+  image_entities: https://w3id.org/cetmd/image_entities/
+  #alignment: https://w3id.org/cetmd/alignment/
 
 default_prefix: image_entities
 
@@ -14,7 +15,7 @@ imports:
 - ./image
 - ./coordinate_systems
 - ./coordinate_transforms
-- ./alignment
+#- ./alignment
 
 slots:
   path:
@@ -22,6 +23,7 @@ slots:
     range: string
   section:
     description: 0-based section index to the entity inside a stack.
+    range: integer
   nominal_tilt_angle:
     description: The tilt angle reported by the microscope
     range: float
@@ -43,6 +45,14 @@ slots:
   ctf_metadata:
     description: A set of CTF patameters for an image.
     range: CTFMetadata
+  images_movie:
+    description: The movie frames in the stack
+    range: MovieFrame
+    multivalued: true
+  images_tilt:
+    description: The projections in the stack
+    range: ProjectionImage
+    multivalued: true
 
 classes:
   CTFMetadata:
@@ -82,13 +92,10 @@ classes:
 
   MovieStack:
     description: A stack of movie frames.
-    attributes:
-      images:
-        description: The movie frames in the stack
-        range: MovieFrame
-        multivalued: true
-      path:
-        range: string
+    slots:
+    - path
+    - images_movie
+
 
   ProjectionImage:
     is_a: Image2D
@@ -109,13 +116,10 @@ classes:
 
   TiltSeries:
     description: A stack of projection images.
-    attributes:
-      images:
-        description: The projections in the stack
-        range: ProjectionImage
-        multivalued: true
-      path:
-        range: string
+    slots:
+    - images_tilt
+    - path
+
 
   SubProjectionImage:
     is_a: ProjectionImage

--- a/schema/linkml/instrument.yaml
+++ b/schema/linkml/instrument.yaml
@@ -1,0 +1,71 @@
+id: https://w3id.org/osc-em/instrument
+name: OSCEMInstrument
+description: >
+  LinkML schema for electron microscopy sample and author-related metadata,
+  broadly following the EMDB standard with some additions.
+prefixes:
+  linkml: https://w3id.org/linkml/
+  instrument: https://w3id.org/osc-em/instrument
+
+imports:
+  - linkml:types
+  - ./custom_types
+
+#default_prefix: instrument
+
+classes:
+  Instrument:
+    description: Instrument values, mostly constant across a data collection.
+    slots:
+    - microscope
+    - illumination
+    - imaging
+    - electron_source
+    - acceleration_voltage
+    - c2_aperture
+    - cs
+    slot_usage:
+      microscope:
+        required: true
+      illumination:
+        required: true
+      imaging:
+        required: true
+      electron_source:
+        required: true
+      acceleration_voltage:
+        required: true
+      cs:
+        required: true
+
+slots:
+  microscope:
+    description: Name/Type of the Microscope
+    range: string
+  illumination:
+    description: Mode of illumination used during data collection
+    range: string
+  imaging:
+    description: Mode of imaging used during data collection
+    range: string
+  electron_source:
+    description: Type of electron source used in the microscope, such as FEG
+    range: string
+  acceleration_voltage:
+    description: Voltage used for the electron acceleration, in kV
+    range: Any
+    any_of:
+      - range:  QuantityValue
+      - range:  QuantitySI
+  c2_aperture:
+    description: C2 aperture size used in data acquisition, in µm
+    range: Any
+    any_of:
+      - range:  QuantityValue
+      - range:  QuantitySI
+  cs:
+    description: Spherical aberration of the instrument, in mm
+    range: Any
+    any_of:
+      - range:  QuantityValue
+      - range:  QuantitySI

--- a/schema/linkml/tomography.yaml
+++ b/schema/linkml/tomography.yaml
@@ -1,0 +1,44 @@
+id: https://w3id.org/osc-em/tomography
+name: TomoAdditionalFields
+description: Mixin for additional fields for tomography datasets
+
+prefixes:
+  types: https://w3id.org/osc-em/custom_types
+  tomo: https://w3id.org/osc-em/tomo
+
+#default_prefix: tomo
+
+imports:
+  - ./custom_types
+  - acquisition
+
+classes:
+  TiltAngle:
+    description: The min, max and increment of the tilt angle in a tomography session. Unit is degree.
+    is_a: Series
+    slot_usage:
+      minimal:
+        required: true
+      maximal:
+        required: true
+      increment:
+        required: true
+
+  AcquisitionTomo:
+    is_a: Acquisition
+    slots:
+      - tilt_axis_angle
+      - tilt_angle
+    slot_usage:
+      tilt_axis_angle:
+        required: true
+      tilt_angle:
+        required: true
+
+slots:
+  tilt_axis_angle:
+    range: float
+    description: The tilt axis angle of a tomography series
+  tilt_angle:
+    range: TiltAngle
+    description: The min, max and increment of the tilt angle in a tomography session. Unit is degree.


### PR DESCRIPTION
as discussed here an example of how the extension of linkml compatibility and addition of acquisition parameters could look like. the docs can now also be autogenerated (linkml gen-doc) allowing for more comfortable viewing.